### PR TITLE
fix: fix key error caused by failed_join_potential

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,9 @@ COBRA (Contig Overlap Based Re-Assembly) is a bioinformatics tool to get higher 
 1. v1.2.2 (released on 2023-09-03) - initial release
 
 2. v1.2.3 (released on 2024-02-26)
-```
-# The GC function issue due to the update of Biopython.
-# The abnormal exit in the middle of processing some samples.
-# If none of the queries was extended, the process will break. If your runs do not have the expected output files,
-see the log file.
-```
+- The GC function issue due to the update of Biopython.
+- The abnormal exit in the middle of processing some samples.
+- If none of the queries was extended, the process will break. If your runs do not have the expected output files, see the log file.
 
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![COBRA_logo](https://github.com/linxingchen/cobra/assets/46725273/f21d1198-991c-42b2-9ec0-0ae8a662ba35)
 
-COBRA (Contig Overlap Based Re-Assembly) is a bioinformatics tool to get higher quality viral genomes assembled from metagenomes of short paired-end reads. COBRA was written in Python. COBRA has so far only been tested on assembled contigs from metaSPAdes, IDBA_UD, and MEGAHIT.
+COBRA (Contig Overlap Based Re-Assembly) is a bioinformatics tool to get higher quality viral genomes assembled from metagenomes of short paired-end reads. COBRA was written in Python. COBRA has so far only been tested on assembled contigs and scaffolds from metaSPAdes, IDBA_UD, and MEGAHIT.
 
 ```
 # Developed by Dr. LinXing Chen

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ COBRA (Contig Overlap Based Re-Assembly) is a bioinformatics tool to get higher 
 ```
 
 ## Versions
-v1.2.3 (released on 2024-02-26)
+1. v1.2.3 (released on 2024-02-26)
 ```
-1. The GC function issue due to the update of Biopython.
-2. The abnormal exit in the middle of processing some samples.
-3. If none of the queries was extended, the process will break. If your runs
-do not have the expected output files, see the log file.
+# The GC function issue due to the update of Biopython.
+# The abnormal exit in the middle of processing some samples.
+# If none of the queries was extended, the process will break. If your runs do not have the expected output files,
+see the log file.
 ```
+
 
 ## Citation
 The paper is out at Nature Microbiology (https://www.nature.com/articles/s41564-023-01598-2). Please cite as follows if you find COBRA is helpful for your analyses. 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,7 @@ usage: cobra-meta [-h] -q QUERY -f FASTA -a {idba,megahit,metaspades} -mink MINK
 
 ```conda activate cobra```
 
-```conda install bioconda::cobra-meta``` (v1.2.2)
-
-```conda install linxingchen1987::cobra-meta``` (v1.2.3)
+```conda install bioconda::cobra-meta``` or ```conda install linxingchen1987::cobra-meta```
 
 To confirm the installment,
 
@@ -112,6 +110,12 @@ usage: cobra-meta [-h] -q QUERY -f FASTA -a {idba,megahit,metaspades} -mink MINK
 * pip
   
 ```pip install --upgrade cobra-meta```
+
+* conda
+
+``` conda activate cobra``` (if cobra is the conda environment name)
+
+``` conda update cobra-meta```
 
 ##
 ## Input files

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ which shows your something like this
 ```
 usage: cobra-meta [-h] -q QUERY -f FASTA -a {idba,megahit,metaspades} -mink MINK -maxk MAXK -m MAPPING -c COVERAGE [-lm LINKAGE_MISMATCH] [-o OUTPUT] [-t THREADS] [-v]
 
-This script is used to get higher quality (including circular) virus genomes by joining assembled contigs based on their end overlaps.
-
 ...
 ```
 
@@ -97,6 +95,18 @@ This script is used to get higher quality (including circular) virus genomes by 
 ```conda install bioconda::cobra-meta``` (v1.2.2)
 
 ```conda install linxingchen1987::cobra-meta``` (v1.2.3)
+
+To confirm the installment,
+
+```cobra-meta -h```
+
+which shows your something like this
+
+```
+usage: cobra-meta [-h] -q QUERY -f FASTA -a {idba,megahit,metaspades} -mink MINK -maxk MAXK -m MAPPING -c COVERAGE [-lm LINKAGE_MISMATCH] [-o OUTPUT] [-t THREADS] [-v]
+
+...
+```
 
 ## Update
 * pip

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This script is used to get higher quality (including circular) virus genomes by 
 
 ```conda activate cobra```
 
-```conda install cobra-meta``` (v1.2.2)
+```conda install bioconda::cobra-meta``` (v1.2.2)
 
 ```conda install linxingchen1987::cobra-meta``` (v1.2.3)
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
 ![COBRA_logo](https://github.com/linxingchen/cobra/assets/46725273/f21d1198-991c-42b2-9ec0-0ae8a662ba35)
 
-# COBRA
 COBRA (Contig Overlap Based Re-Assembly) is a bioinformatics tool to get higher quality viral genomes assembled from metagenomes of short paired-end reads. COBRA was written in Python. COBRA has so far only been tested on assembled contigs from metaSPAdes, IDBA_UD, and MEGAHIT.
 
-** current version = v1.2.3 **
+```
+# Developed by Dr. LinXing Chen
+# University of California, Berkeley
+# The Banfield Lab
+# Email: linkingchan@gmail.com
+```
 
-## Bugs fixed in version v1.2.3
+## Versions
+v1.2.3 (released on 2024-02-26)
+```
 1. The GC function issue due to the update of Biopython.
 2. The abnormal exit in the middle of processing some samples.
-3. If none of the queries was extended, the process will break. If your run does not have the expected output files, see the log file.
+3. If none of the queries was extended, the process will break. If your runs
+do not have the expected output files, see the log file.
+```
+
+## Citation
+The paper is out at Nature Microbiology (https://www.nature.com/articles/s41564-023-01598-2). Please cite if you find it helpful for your analyses.
+
 
 ## Introduction
 
@@ -30,7 +42,7 @@ According to the principles of the abovementioned assemblers, the broken contigs
 
 Figure 2. The "expected overlap length" has been documented in manual genome curation, see [Chen et al. 2020](https://genome.cshlp.org/content/30/3/315.short) for details.
 
-##
+
 ## How COBRA works
 
 COBRA determines the "expected overlap length" (both the forward direction and reverse complement direction) for all the contigs from an assembly, then looks for the valid joining path for each query that users provide (should be a fraction of the whole assembly) based on a list of features including contig coverage, contig overlap relationships, and contig continuity (based on paired-end reads mapping) (Figure 3).
@@ -43,7 +55,7 @@ Given that COBRA has only tested for contigs/scaffolds from IDBA_UD, metaSPAdes 
 
 Figure 3. The workflow of COBRA.
 
-##
+
 ## Dependencies
 * COBRA is a Python script (tested for version 3.7 or higher) that uses a list of frequently used Python packages including:
 ```
@@ -117,7 +129,7 @@ usage: cobra-meta [-h] -q QUERY -f FASTA -a {idba,megahit,metaspades} -mink MINK
 
 ``` conda update cobra-meta```
 
-##
+
 ## Input files
 (1) COBRA needs four files as inputs, i.e., 
 
@@ -148,7 +160,7 @@ contig-140_4    41.2746
 * ```-o/--output```: the name of the output folder, otherwise it will be "{```-q/--query```}.COBRA" if not provided.
 * ```-t/--threads```: the number of threads used for BLASTn search.
 
-##
+
 ## How to obtain the mapping file
 
 The mapping file could be obtained with tools like Bowtie2 and BBMap, please refer to the manual descriptions for details of the tools. Below is the general way to get the sorted sam/bam file, you thus need to be available to samtools (which could be get here - https://github.com/samtools/samtools).
@@ -200,7 +212,6 @@ CoverM is a fast DNA read coverage and relative abundance calculator focused on 
 pyCoverM is a simple Python interface to CoverM's fast coverage estimation functions, which could be found here (https://github.com/apcamargo/pycoverm).
 
 
-##
 ## How to run
 (1) The users can only specify the required parameters:
 
@@ -222,7 +233,7 @@ cobra-meta -f all.contigs.fasta -q query.fasta -o query.fasta.COBRA.out -c cover
 cobra-meta -f all.contigs.fasta -q query.fasta -o query.fasta.COBRA.out -c coverage.txt -m mapping.sam -a megahit -mink 21 -maxk 141 -mm 2
 ```
 
-##
+
 ## Output files
 Below is a general list of output files in the output folder:
 
@@ -321,11 +332,3 @@ contig-140_188  38386   5       48986   48291   9905    Extended_circular
 # Check "COBRA_joining_summary.txt" for joining details of "Extended_circular" and "Extended_partial" queries.
 ======================================================================================================================================================
 ```
-
-##
-## Citation
-The paper is out at Nature Microbiology (https://www.nature.com/articles/s41564-023-01598-2). Please cite if you find it helpful for your analyses.
-
-##
-## Questions
-Please do not hesitate to contact me for any questions you have when using COBRA via my email (linkingchan@gmail.com), or Twitter (https://twitter.com/ChenLinxing).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ COBRA (Contig Overlap Based Re-Assembly) is a bioinformatics tool to get higher 
 ```
 
 ## Versions
-1. v1.2.3 (released on 2024-02-26)
+1. v1.2.2 (released on 2023-09-03) - initial release
+
+2. v1.2.3 (released on 2024-02-26)
 ```
 # The GC function issue due to the update of Biopython.
 # The abnormal exit in the middle of processing some samples.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ do not have the expected output files, see the log file.
 ```
 
 ## Citation
-The paper is out at Nature Microbiology (https://www.nature.com/articles/s41564-023-01598-2). Please cite if you find it helpful for your analyses.
+The paper is out at Nature Microbiology (https://www.nature.com/articles/s41564-023-01598-2). Please cite as follows if you find COBRA is helpful for your analyses. 
+```Chen, L., Banfield, J.F. COBRA improves the completeness and contiguity of viral genomes assembled from metagenomes. Nat Microbiol (2024). https://doi.org/10.1038/s41564-023-01598-2```
 
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ This script is used to get higher quality (including circular) virus genomes by 
 
 ```conda activate cobra```
 
-```conda install cobra-meta```
+```conda install cobra-meta``` (v1.2.2)
+
+```conda install linxingchen1987::cobra-meta``` (v1.2.3)
 
 ## Update
 * pip

--- a/cobra.py
+++ b/cobra.py
@@ -1730,96 +1730,104 @@ def main(
     header2joined_seq = {}
     contig2extended_status = {}
     for contig in order_all:
-        a = open(f"{working_dir}/COBRA_retrieved_for_joining/{contig}_retrieved_joined.fa", "w")
-        last = ""
-        # print header regarding the joining status
-        label = "_extended_circular" if contig in path_circular else "_extended_partial"
-        a.write(">" + contig + label + "\n")
-        header2joined_seq[contig + label] = ""
-        contig2extended_status[contig] = contig + label
+        with open(
+            f"{working_dir}/COBRA_retrieved_for_joining/{contig}_retrieved_joined.fa",
+            "w",
+        ) as a:
+            last = ""
+            # print header regarding the joining status
+            label = (
+                "_extended_circular" if contig in path_circular else "_extended_partial"
+            )
+            a.write(">" + contig + label + "\n")
+            header2joined_seq[contig + label] = ""
+            contig2extended_status[contig] = contig + label
 
-        # print the sequences with their overlap removed
-        for item in order_all[contig][:-1]:
-            if item.endswith("_R") or item.endswith("_L"):
-                if last == "":
-                    a.write(header2seq[item.rsplit("_", 1)[0]][:-maxk_length])
-                    last = header2seq[item.rsplit("_", 1)[0]][-maxk_length:]
-                    header2joined_seq[contig2extended_status[contig]] += header2seq[
-                        item.rsplit("_", 1)[0]
-                    ][:-maxk_length]
-                else:
-                    if header2seq[item.rsplit("_", 1)[0]][:maxk_length] == last:
+            # print the sequences with their overlap removed
+            for item in order_all[contig][:-1]:
+                if item.endswith("_R") or item.endswith("_L"):
+                    if last == "":
                         a.write(header2seq[item.rsplit("_", 1)[0]][:-maxk_length])
                         last = header2seq[item.rsplit("_", 1)[0]][-maxk_length:]
                         header2joined_seq[contig2extended_status[contig]] += header2seq[
                             item.rsplit("_", 1)[0]
                         ][:-maxk_length]
-            elif item.endswith("rc"):
-                if last == "":
-                    a.write(
-                        reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                    else:
+                        if header2seq[item.rsplit("_", 1)[0]][:maxk_length] == last:
+                            a.write(header2seq[item.rsplit("_", 1)[0]][:-maxk_length])
+                            last = header2seq[item.rsplit("_", 1)[0]][-maxk_length:]
+                            header2joined_seq[
+                                contig2extended_status[contig]
+                            ] += header2seq[item.rsplit("_", 1)[0]][:-maxk_length]
+                elif item.endswith("rc"):
+                    if last == "":
+                        a.write(
+                            reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                                :-maxk_length
+                            ]
+                        )
+                        last = reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                            -maxk_length:
+                        ]
+                        header2joined_seq[
+                            contig2extended_status[contig]
+                        ] += reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
                             :-maxk_length
                         ]
-                    )
-                    last = reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
-                        -maxk_length:
-                    ]
-                    header2joined_seq[
-                        contig2extended_status[contig]
-                    ] += reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
-                        :-maxk_length
-                    ]
-                elif (
-                    reverse_complement(header2seq[item.rsplit("_", 1)[0]])[:maxk_length]
-                    == last
-                ):
-                    a.write(
+                    elif (
                         reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                            :maxk_length
+                        ]
+                        == last
+                    ):
+                        a.write(
+                            reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                                :-maxk_length
+                            ]
+                        )
+                        last = reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                            -maxk_length:
+                        ]
+                        header2joined_seq[
+                            contig2extended_status[contig]
+                        ] += reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
                             :-maxk_length
                         ]
+                else:
+                    if last == "":
+                        a.write(header2seq[contig][:-maxk_length])
+                        last = header2seq[contig][-maxk_length:]
+                        header2joined_seq[contig2extended_status[contig]] += header2seq[
+                            contig
+                        ][:-maxk_length]
+                    elif header2seq[contig][:maxk_length] == last:
+                        a.write(header2seq[contig][:-maxk_length])
+                        last = header2seq[contig][-maxk_length:]
+                        header2joined_seq[contig2extended_status[contig]] += header2seq[
+                            contig
+                        ][:-maxk_length]
+            if order_all[contig][-1].endswith("rc"):
+                a.write(
+                    reverse_complement(
+                        header2seq[order_all[contig][-1].rsplit("_", 1)[0]]
                     )
-                    last = reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
-                        -maxk_length:
-                    ]
-                    header2joined_seq[
-                        contig2extended_status[contig]
-                    ] += reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
-                        :-maxk_length
-                    ]
+                    + "\n"
+                )
+                header2joined_seq[contig2extended_status[contig]] += reverse_complement(
+                    header2seq[order_all[contig][-1].rsplit("_", 1)[0]]
+                )
+            elif order_all[contig][-1].endswith("_R") or order_all[contig][-1].endswith(
+                "_L"
+            ):
+                a.write(header2seq[order_all[contig][-1].rsplit("_", 1)[0]] + "\n")
+                header2joined_seq[contig2extended_status[contig]] += header2seq[
+                    order_all[contig][-1].rsplit("_", 1)[0]
+                ]
             else:
-                if last == "":
-                    a.write(header2seq[contig][:-maxk_length])
-                    last = header2seq[contig][-maxk_length:]
-                    header2joined_seq[contig2extended_status[contig]] += header2seq[
-                        contig
-                    ][:-maxk_length]
-                elif header2seq[contig][:maxk_length] == last:
-                    a.write(header2seq[contig][:-maxk_length])
-                    last = header2seq[contig][-maxk_length:]
-                    header2joined_seq[contig2extended_status[contig]] += header2seq[
-                        contig
-                    ][:-maxk_length]
-        if order_all[contig][-1].endswith("rc"):
-            a.write(
-                reverse_complement(header2seq[order_all[contig][-1].rsplit("_", 1)[0]])
-                + "\n"
-            )
-            header2joined_seq[contig2extended_status[contig]] += reverse_complement(
-                header2seq[order_all[contig][-1].rsplit("_", 1)[0]]
-            )
-        elif order_all[contig][-1].endswith("_R") or order_all[contig][-1].endswith(
-            "_L"
-        ):
-            a.write(header2seq[order_all[contig][-1].rsplit("_", 1)[0]] + "\n")
-            header2joined_seq[contig2extended_status[contig]] += header2seq[
-                order_all[contig][-1].rsplit("_", 1)[0]
-            ]
-        else:
-            a.write(header2seq[order_all[contig][-1]] + "\n")
-            header2joined_seq[contig2extended_status[contig]] += header2seq[
-                order_all[contig][-1]
-            ]
-        a.close()
+                a.write(header2seq[order_all[contig][-1]] + "\n")
+                header2joined_seq[contig2extended_status[contig]] += header2seq[
+                    order_all[contig][-1]
+                ]
 
     os.chdir(f"{working_dir}")
     print("contig2extended_status", file=debug, flush=True)

--- a/cobra.py
+++ b/cobra.py
@@ -2269,10 +2269,10 @@ def main(
         for contig in contig2assembly[query]
     }
     with open(f"{working_dir}/{assem_fa.rsplit('/', 1)[-1]}.new.fa", "w") as new:
-        for header, sequence in sorted(header2seq.keys() - query_extension_used.keys()):
-            print(f">{header}\n{sequence}\n", file=new)
+        for header in sorted(header2seq.keys() - query_extension_used.keys()):
+            print(f">{header}\n{header2seq[header]}\n", file=new)
     os.system(
-        f"cat {extended_circular_fasta.name} {extended_partial_fasta.name} > {new.name}"
+        f"cat {extended_circular_fasta.name} {extended_partial_fasta.name} >> {new.name}"
     )
     ##
     # intermediate files

--- a/cobra.py
+++ b/cobra.py
@@ -1336,12 +1336,7 @@ def main(
     for k in sorted(contig2assembly):
         print(k, sorted(contig2assembly[k]), file=debug, flush=True)
 
-    failed_join_list_back = list(failed_join_list)
-    path_circular_back = set(path_circular)
     ##
-    # path_circular = set(path_circular_back)
-    # is_subset_of = {}
-    failed_join_list = list(failed_join_list_back)
     # find the redundant joining paths
     redundant: set[str] = set()
     is_same_as: dict[str, set[str]] = {}

--- a/cobra.py
+++ b/cobra.py
@@ -6,21 +6,22 @@
 # Modification date: Sep 3, 2023
 
 
+import argparse
+import itertools
 import os
+from collections import defaultdict
+from time import strftime
+
 import Bio
+import pysam
 from Bio import SeqIO
 from Bio.Seq import reverse_complement
-from collections import defaultdict
-import argparse
-import pysam
-from time import strftime
-import itertools
 
 bio_version = Bio.__version__
 if bio_version > "1.79":
     from Bio.SeqUtils import gc_fraction as GC
 else:
-    from Bio.SeqUtils import GC
+    from Bio.SeqUtils import GC  # type: ignore
 
 parser = argparse.ArgumentParser(
     description="This script is used to get higher quality (including circular) virus genomes "

--- a/cobra.py
+++ b/cobra.py
@@ -1234,11 +1234,11 @@ def main(
                     # >>>>>>>>>>>>>>......>>>>>>>>>>>>>
                     # |           | ...... |           |
                     # ^- 0        ^- 500   ^- -500     ^- -0
-                    # +++++++ ... |        |             |
-                    #         ... +++++++  |             |
+                    # +++++++ ... |        |
+                    #         ... +++++++  |
                     #   @read_i/1 .        |
-                    #             .        +++++++       |
-                    #             .        .     +++++++ |
+                    #             .        +++++++
+                    #             .        .     +++++++
                     #             .        .  @read_i/2
                     #             |--------| <- header2len[contig1] - 1000
                     #
@@ -1257,30 +1257,25 @@ def main(
         ):
             self_circular.add(contig)
 
-    debug = open("{0}/debug.txt".format(working_dir), "w")
+    debug = open(f"{working_dir}/debug.txt", "w")
 
     # for debug
-    print("self_circular", file=debug, flush=True)
-    print(self_circular, file=debug, flush=True)
+    print(f"# self_circular: {len(self_circular)}", file=debug, flush=True)
+    print(sorted(self_circular), file=debug, flush=True)
 
     # orphan end queries info
     # determine potential self_circular contigs from contigs with orphan end
 
-    min_over_len = 0
-    if assembler == "idba":
-        min_over_len = mink - 1
-    else:
-        min_over_len = mink
+    min_over_len = mink - 1 if assembler == "idba" else mink
 
     # determine if there is DTR for those query with orphan ends, if yes, assign as self_circular as well
-    for contig in orphan_end_query:
-        if contig in parsed_contig_spanned_by_PE_reads:
-            sequence = header2seq[contig]
-            end_part = sequence[-min_over_len:]
-            if sequence.count(end_part) == 2:
-                expected_end = sequence.split(end_part)[0] + end_part
-                if sequence.endswith(expected_end):
-                    self_circular_non_expected_overlap[contig] = len(expected_end)
+    for contig in parsed_contig_spanned_by_PE_reads:
+        sequence = header2seq[contig]
+        end_part = sequence[-min_over_len:]
+        if sequence.count(end_part) == 2:
+            expected_end = sequence.split(end_part)[0] + end_part
+            if sequence.endswith(expected_end):
+                self_circular_non_expected_overlap[contig] = len(expected_end)
 
     for contig in self_circular_non_expected_overlap:
         orphan_end_query.remove(contig)

--- a/cobra.py
+++ b/cobra.py
@@ -418,6 +418,18 @@ def detect_self_circular(
             # |----->...|----->
             # >the other contig ends with `|----->` <
             #
+            if link_pair[end][0].rsplit("_", 1)[0] == link_pair[end][1].rsplit("_", 1)[0]:
+                #           >contig
+                #           |----->...|----->
+                #           |- L ->
+                #           |- R ->
+                # |----->...|----->
+                #                     contig< | FIXME: Why this happened?
+                #           |~Rrc~>...|~Lrc~> |
+                # |~Rrc~>...|~Lrc~>           |
+                print("Warning: Unexpected self-multipile circular: ", contig, flush=True)
+                print("       : from", end, "to", link_pair[end], flush=True)
+                return ""
             return "two_paths_end"
     return ""
 

--- a/cobra.py
+++ b/cobra.py
@@ -25,19 +25,6 @@ else:
     from Bio.SeqUtils import GC  # type: ignore
 
 
-class COBRA_ARGS(TypedDict):
-    query: str
-    fasta: str
-    assembler: Literal["idba", "megahit", "metaspades"]
-    mink: int
-    maxk: int
-    mapping: str
-    coverage: str
-    linkage_mismatch: int
-    output: str
-    threads: int
-
-
 def parse_args():
     parser = argparse.ArgumentParser(
         description="This script is used to get higher quality (including circular) virus genomes "
@@ -801,7 +788,6 @@ def total_length(contig_list: list[str]):
 
 
 def main(
-    args,
     query_fa: str,
     assem_fa: str,
     mapping_file: str,
@@ -811,6 +797,7 @@ def main(
     assembler: Literal["idba", "megahit", "metaspades"],
     outdir: str = "",
     linkage_mismatch: int = 2,
+    threads = 1
 ):
     ##
     # get information from the input files and parameters and save information
@@ -1857,8 +1844,10 @@ def main(
     else:
         os.system("makeblastdb -in blastdb_1.fa -dbtype nucl")
         os.system(
-            "blastn -task blastn -db blastdb_1.fa -query blastdb_2.fa -out blastdb_2.vs.blastdb_1 -evalue 1e-10 "
-            "-outfmt 6 -perc_identity 70 -num_threads {0}".format(args.threads)
+            "blastn "
+            "-task blastn -db blastdb_1.fa -query blastdb_2.fa "
+            "-out blastdb_2.vs.blastdb_1 -evalue 1e-10 "
+            f"-outfmt 6 -perc_identity 70 -num_threads {threads}"
         )
 
     # parse the blastn results
@@ -2480,7 +2469,6 @@ def main(
 if __name__ == "__main__":
     args = parse_args()
     main(
-        args,
         query_fa=args.query,
         assem_fa=args.fasta,
         mapping_file=args.mapping,
@@ -2490,4 +2478,5 @@ if __name__ == "__main__":
         assembler=args.assembler,
         outdir=args.output,
         linkage_mismatch=args.linkage_mismatch,
+        threads=args.threads,
     )

--- a/cobra.py
+++ b/cobra.py
@@ -17,45 +17,104 @@ from time import strftime
 import itertools
 
 bio_version = Bio.__version__
-if bio_version > '1.79':
+if bio_version > "1.79":
     from Bio.SeqUtils import gc_fraction as GC
 else:
     from Bio.SeqUtils import GC
 
-parser = argparse.ArgumentParser(description="This script is used to get higher quality (including circular) virus genomes "
-                                             "by joining assembled contigs based on their end overlaps.")
-requiredNamed = parser.add_argument_group('required named arguments')
-requiredNamed.add_argument("-q", "--query", type=str, help="the query contigs file (fasta format), or the query name "
-                                                           "list (text file, one column).", required=True)
-requiredNamed.add_argument("-f", "--fasta", type=str, help="the whole set of assembled contigs (fasta format).", required=True)
-requiredNamed.add_argument("-a", "--assembler", type=str, choices=["idba", "megahit", "metaspades"],
-                           help="de novo assembler used, COBRA not tested for others.", required=True)
-requiredNamed.add_argument("-mink", "--mink", type=int, help="the min kmer size used in de novo assembly.", required=True)
-requiredNamed.add_argument("-maxk", "--maxk", type=int, help="the max kmer size used in de novo assembly.", required=True)
-requiredNamed.add_argument("-m", "--mapping", type=str, help="the reads mapping file in sam or bam format.", required=True)
-requiredNamed.add_argument("-c", "--coverage", type=str, help="the contig coverage file (two columns divided by tab).",
-                           required=True)
-parser.add_argument("-lm", "--linkage_mismatch", type=int, default=2, help="the max read mapping mismatches for "
-                                                                           "determining if two contigs are spanned by "
-                                                                           "paired reads. [2]")
-parser.add_argument("-o", "--output", type=str, help="the name of output folder (default = '<query>_COBRA').")
-parser.add_argument("-t", "--threads", type=int, default=16, help="the number of threads for blastn. [16]")
-parser.add_argument("-v", "--version", action='version', version='cobra v1.2.3')
+parser = argparse.ArgumentParser(
+    description="This script is used to get higher quality (including circular) virus genomes "
+    "by joining assembled contigs based on their end overlaps."
+)
+requiredNamed = parser.add_argument_group("required named arguments")
+requiredNamed.add_argument(
+    "-q",
+    "--query",
+    type=str,
+    help="the query contigs file (fasta format), or the query name "
+    "list (text file, one column).",
+    required=True,
+)
+requiredNamed.add_argument(
+    "-f",
+    "--fasta",
+    type=str,
+    help="the whole set of assembled contigs (fasta format).",
+    required=True,
+)
+requiredNamed.add_argument(
+    "-a",
+    "--assembler",
+    type=str,
+    choices=["idba", "megahit", "metaspades"],
+    help="de novo assembler used, COBRA not tested for others.",
+    required=True,
+)
+requiredNamed.add_argument(
+    "-mink",
+    "--mink",
+    type=int,
+    help="the min kmer size used in de novo assembly.",
+    required=True,
+)
+requiredNamed.add_argument(
+    "-maxk",
+    "--maxk",
+    type=int,
+    help="the max kmer size used in de novo assembly.",
+    required=True,
+)
+requiredNamed.add_argument(
+    "-m",
+    "--mapping",
+    type=str,
+    help="the reads mapping file in sam or bam format.",
+    required=True,
+)
+requiredNamed.add_argument(
+    "-c",
+    "--coverage",
+    type=str,
+    help="the contig coverage file (two columns divided by tab).",
+    required=True,
+)
+parser.add_argument(
+    "-lm",
+    "--linkage_mismatch",
+    type=int,
+    default=2,
+    help="the max read mapping mismatches for "
+    "determining if two contigs are spanned by "
+    "paired reads. [2]",
+)
+parser.add_argument(
+    "-o",
+    "--output",
+    type=str,
+    help="the name of output folder (default = '<query>_COBRA').",
+)
+parser.add_argument(
+    "-t",
+    "--threads",
+    type=int,
+    default=16,
+    help="the number of threads for blastn. [16]",
+)
+parser.add_argument("-v", "--version", action="version", version="cobra v1.2.3")
 args = parser.parse_args()
 
 ##
 #
-global one_path_end, link_pair, cov, parsed_linkage, self_circular, two_paths_end, contig2join, contig_checked, \
-    contig2join_reason, path_circular, path_circular_end, order_all, added_to_contig, header2seq, \
-    self_circular_non_expected_overlap, all_joined_query, extended_circular_query, extended_partial_query, \
-    header2len, is_subset_of
+global one_path_end, link_pair, cov, parsed_linkage, self_circular, two_paths_end, contig2join, contig_checked, contig2join_reason, path_circular, path_circular_end, order_all, added_to_contig, header2seq, self_circular_non_expected_overlap, all_joined_query, extended_circular_query, extended_partial_query, header2len, is_subset_of
 
 #
 cov = {}  # the coverage of contigs
 header2seq = {}
 header2len = {}
 link_pair = {}  # used to save all overlaps between ends
-parsed_linkage = set()  # Initialize an empty set to store the parsed linkage information
+parsed_linkage = (
+    set()
+)  # Initialize an empty set to store the parsed linkage information
 one_path_end = []  # the end of contigs with one potential join
 two_paths_end = []  # the end of contigs with two potential joins
 self_circular = set()
@@ -76,7 +135,15 @@ all_joined_query = set()
 ##
 # define functions for analyses
 def log_info(step, description, line_feed, log_file):
-    localtime = ' [20' + strftime("%x").rsplit('/', 1)[1] + '/' + strftime("%x").rsplit('/', 1)[0] + ' ' + strftime("%X") + '] '
+    localtime = (
+        " [20"
+        + strftime("%x").rsplit("/", 1)[1]
+        + "/"
+        + strftime("%x").rsplit("/", 1)[0]
+        + " "
+        + strftime("%X")
+        + "] "
+    )
     print(step + localtime + description, end=line_feed, file=log_file, flush=True)
 
 
@@ -85,7 +152,7 @@ def determine_file_format(filename):
     Determine the format of the input file.
     Returns either "fasta" or "txt" based on the content.
     """
-    with open(filename, 'r') as f:
+    with open(filename, "r") as f:
         first_line = f.readline().strip()
         if first_line.startswith(">"):
             return "fasta"
@@ -97,8 +164,13 @@ def contig_name(end_name):
     """
     get contig name from end name
     """
-    if end_name.endswith('_L') or end_name.endswith('_R') or end_name.endswith('_Lrc') or end_name.endswith('_Rrc'):
-        return end_name.rsplit('_', 1)[0]
+    if (
+        end_name.endswith("_L")
+        or end_name.endswith("_R")
+        or end_name.endswith("_Lrc")
+        or end_name.endswith("_Rrc")
+    ):
+        return end_name.rsplit("_", 1)[0]
     else:
         return end_name
 
@@ -107,43 +179,59 @@ def get_target(item):
     """
     to get the target for next run of joining
     """
-    suffix = item.rsplit('_', 1)[1]
-    base_name = item.rsplit('_', 1)[0]
+    suffix = item.rsplit("_", 1)[1]
+    base_name = item.rsplit("_", 1)[0]
 
-    if suffix == 'Lrc':
-        return base_name + '_Rrc'
-    elif suffix == 'Rrc':
-        return base_name + '_Lrc'
-    elif suffix == 'R':
-        return base_name + '_L'
+    if suffix == "Lrc":
+        return base_name + "_Rrc"
+    elif suffix == "Rrc":
+        return base_name + "_Lrc"
+    elif suffix == "R":
+        return base_name + "_L"
     else:
-        return base_name + '_R'
+        return base_name + "_R"
 
 
 def are_equal_paths(two_paths):
     """
     evaluate if two paths are equal, two_paths is a list including two ends, e.g., a_L, b_R
     """
-    if two_paths[0].rsplit('_', 1)[1].startswith('L') and two_paths[1].rsplit('_', 1)[1].startswith('R'):
-        return contig_name(two_paths[0]) + '_R' in one_path_end \
-               and contig_name(two_paths[1]) + '_L' in one_path_end \
-               and contig_name(link_pair[contig_name(two_paths[0]) + '_R'][0]) == \
-               contig_name(link_pair[contig_name(two_paths[1]) + '_L'][0])
-    elif two_paths[0].rsplit('_', 1)[1].startswith('R') and two_paths[1].rsplit('_', 1)[1].startswith('L'):
-        return contig_name(two_paths[0]) + '_L' in one_path_end \
-               and contig_name(two_paths[1]) + '_R' in one_path_end \
-               and contig_name(link_pair[contig_name(two_paths[0]) + '_L'][0]) == \
-               contig_name(link_pair[contig_name(two_paths[1]) + '_R'][0])
-    elif two_paths[0].rsplit('_', 1)[1].startswith('R') and two_paths[1].rsplit('_', 1)[1].startswith('R'):
-        return contig_name(two_paths[0]) + '_L' in one_path_end \
-               and contig_name(two_paths[1]) + '_L' in one_path_end \
-               and contig_name(link_pair[contig_name(two_paths[0]) + '_L'][0]) == \
-               contig_name(link_pair[contig_name(two_paths[1]) + '_L'][0])
-    elif two_paths[0].rsplit('_', 1)[1].startswith('L') and two_paths[1].rsplit('_', 1)[1].startswith('L'):
-        return contig_name(two_paths[0]) + '_R' in one_path_end \
-               and contig_name(two_paths[1]) + '_R' in one_path_end \
-               and contig_name(link_pair[contig_name(two_paths[0]) + '_R'][0]) == \
-               contig_name(link_pair[contig_name(two_paths[1]) + '_R'][0])
+    if two_paths[0].rsplit("_", 1)[1].startswith("L") and two_paths[1].rsplit("_", 1)[
+        1
+    ].startswith("R"):
+        return (
+            contig_name(two_paths[0]) + "_R" in one_path_end
+            and contig_name(two_paths[1]) + "_L" in one_path_end
+            and contig_name(link_pair[contig_name(two_paths[0]) + "_R"][0])
+            == contig_name(link_pair[contig_name(two_paths[1]) + "_L"][0])
+        )
+    elif two_paths[0].rsplit("_", 1)[1].startswith("R") and two_paths[1].rsplit("_", 1)[
+        1
+    ].startswith("L"):
+        return (
+            contig_name(two_paths[0]) + "_L" in one_path_end
+            and contig_name(two_paths[1]) + "_R" in one_path_end
+            and contig_name(link_pair[contig_name(two_paths[0]) + "_L"][0])
+            == contig_name(link_pair[contig_name(two_paths[1]) + "_R"][0])
+        )
+    elif two_paths[0].rsplit("_", 1)[1].startswith("R") and two_paths[1].rsplit("_", 1)[
+        1
+    ].startswith("R"):
+        return (
+            contig_name(two_paths[0]) + "_L" in one_path_end
+            and contig_name(two_paths[1]) + "_L" in one_path_end
+            and contig_name(link_pair[contig_name(two_paths[0]) + "_L"][0])
+            == contig_name(link_pair[contig_name(two_paths[1]) + "_L"][0])
+        )
+    elif two_paths[0].rsplit("_", 1)[1].startswith("L") and two_paths[1].rsplit("_", 1)[
+        1
+    ].startswith("L"):
+        return (
+            contig_name(two_paths[0]) + "_R" in one_path_end
+            and contig_name(two_paths[1]) + "_R" in one_path_end
+            and contig_name(link_pair[contig_name(two_paths[0]) + "_R"][0])
+            == contig_name(link_pair[contig_name(two_paths[1]) + "_R"][0])
+        )
     else:
         return False
 
@@ -163,29 +251,41 @@ def could_circulate(point, contig, direction):
     check if the path is circular with the current contig included
     """
     if len(link_pair[point]) == 2:  # point is the same as "target" in join_walker
-        if direction == 'L':
+        if direction == "L":
             if contig_name(link_pair[point][0]) == contig:
                 if cov[contig_name(point)] < 1.5 * cov[contig]:
                     # 2 times is for repeat, but it is too risky, use 1.5 instead (same below)
-                    return link_pair[point][0].endswith('_R') and (contig + '_R', point) in parsed_linkage
+                    return (
+                        link_pair[point][0].endswith("_R")
+                        and (contig + "_R", point) in parsed_linkage
+                    )
                 else:
                     return False
             elif contig_name(link_pair[point][1]) == contig:
                 if cov[contig_name(point)] < 1.5 * cov[contig]:
-                    return link_pair[point][1].endswith('_R') and (contig + '_R', point) in parsed_linkage
+                    return (
+                        link_pair[point][1].endswith("_R")
+                        and (contig + "_R", point) in parsed_linkage
+                    )
                 else:
                     return False
             else:
                 return False
-        elif direction == 'R':
+        elif direction == "R":
             if contig_name(link_pair[point][0]) == contig:
                 if cov[contig_name(point)] < 1.5 * cov[contig]:
-                    return link_pair[point][0].endswith('_L') and (contig + '_L', point) in parsed_linkage
+                    return (
+                        link_pair[point][0].endswith("_L")
+                        and (contig + "_L", point) in parsed_linkage
+                    )
                 else:
                     return False
             elif contig_name(link_pair[point][1]) == contig:
                 if cov[contig_name(point)] < 1.5 * cov[contig]:
-                    return link_pair[point][1].endswith('_L') and (contig + '_L', point) in parsed_linkage
+                    return (
+                        link_pair[point][1].endswith("_L")
+                        and (contig + "_L", point) in parsed_linkage
+                    )
                 else:
                     return False
             else:
@@ -194,12 +294,18 @@ def could_circulate(point, contig, direction):
             return False
 
     elif len(link_pair[point]) == 1:
-        if direction == 'L':
+        if direction == "L":
             if contig_name(link_pair[point][0]) == contig:
-                return link_pair[point][0].endswith('_R') and (contig + '_R', point) in parsed_linkage
-        elif direction == 'R':
+                return (
+                    link_pair[point][0].endswith("_R")
+                    and (contig + "_R", point) in parsed_linkage
+                )
+        elif direction == "R":
             if contig_name(link_pair[point][0]) == contig:
-                return link_pair[point][0].endswith('_L') and (contig + '_L', point) in parsed_linkage
+                return (
+                    link_pair[point][0].endswith("_L")
+                    and (contig + "_L", point) in parsed_linkage
+                )
 
     else:
         return False
@@ -266,16 +372,16 @@ def detect_self_circular(contig):
     """
     to determine the input sequences if they are self_circular genomes or not
     """
-    end = contig + '_L'
+    end = contig + "_L"
     if end in one_path_end:
-        if link_pair[end][0] == contig + '_R':
+        if link_pair[end][0] == contig + "_R":
             # the other end could be joined with the current working end
             self_circular.add(contig)
         else:
             pass
     elif end in two_paths_end:
-        if link_pair[end][0].rsplit('_', 1)[0] != link_pair[end][1].rsplit('_', 1)[0]:
-            if contig + '_R' in link_pair[end]:
+        if link_pair[end][0].rsplit("_", 1)[0] != link_pair[end][1].rsplit("_", 1)[0]:
+            if contig + "_R" in link_pair[end]:
                 self_circular.add(contig)
             else:
                 pass
@@ -291,44 +397,73 @@ def join_walker(contig, direction):
     """
     global contig2join, contig_checked, contig2join_reason, path_circular, path_circular_end
 
-    end = contig + '_' + direction
+    end = contig + "_" + direction
     a = len(contig2join[end])
     if a == 0:
         contig_checked[end].append(contig)
         if end in one_path_end:
             if contig_name(link_pair[end][0]) != contig:
-                if other_end_is_extendable(link_pair[end][0], contig) and (end, link_pair[end][0]) in parsed_linkage \
-                        and contig_name(link_pair[end][0]) not in self_circular:
+                if (
+                    other_end_is_extendable(link_pair[end][0], contig)
+                    and (end, link_pair[end][0]) in parsed_linkage
+                    and contig_name(link_pair[end][0]) not in self_circular
+                ):
                     contig2join[end].append(link_pair[end][0])
                     contig_checked[end].append(contig_name(link_pair[end][0]))
-                    contig2join_reason[contig][contig_name(link_pair[end][0])] = 'other_end_is_extendable'
-                elif is_ok_to_add(link_pair[end][0], contig) and (end, link_pair[end][0]) in parsed_linkage \
-                        and contig_name(link_pair[end][0]) not in self_circular:
+                    contig2join_reason[contig][
+                        contig_name(link_pair[end][0])
+                    ] = "other_end_is_extendable"
+                elif (
+                    is_ok_to_add(link_pair[end][0], contig)
+                    and (end, link_pair[end][0]) in parsed_linkage
+                    and contig_name(link_pair[end][0]) not in self_circular
+                ):
                     contig2join[end].append(link_pair[end][0])
                     contig_checked[end].append(contig_name(link_pair[end][0]))
-                    contig2join_reason[contig][contig_name(link_pair[end][0])] = 'is_ok_to_add'
+                    contig2join_reason[contig][
+                        contig_name(link_pair[end][0])
+                    ] = "is_ok_to_add"
                 else:
                     pass
             else:
                 pass
         elif end in two_paths_end:
-            if link_pair[end][0].rsplit('_', 1)[0] != link_pair[end][1].rsplit('_', 1)[0]:
+            if (
+                link_pair[end][0].rsplit("_", 1)[0]
+                != link_pair[end][1].rsplit("_", 1)[0]
+            ):
                 if are_equal_paths(link_pair[end]):
-                    if contig_name(the_dominant_one(link_pair[end])) not in self_circular:
+                    if (
+                        contig_name(the_dominant_one(link_pair[end]))
+                        not in self_circular
+                    ):
                         contig2join[end].append(the_dominant_one(link_pair[end]))
                         contig_checked[end].append(contig_name((link_pair[end][0])))
                         contig_checked[end].append(contig_name((link_pair[end][1])))
-                        contig2join_reason[contig][contig_name(the_dominant_one(link_pair[end]))] = 'are_equal_paths'
+                        contig2join_reason[contig][
+                            contig_name(the_dominant_one(link_pair[end]))
+                        ] = "are_equal_paths"
                     else:
                         pass
                 else:
-                    if cov[contig_name(link_pair[end][0])] + cov[contig_name(link_pair[end][1])] >= cov[contig] * 0.5:
+                    if (
+                        cov[contig_name(link_pair[end][0])]
+                        + cov[contig_name(link_pair[end][1])]
+                        >= cov[contig] * 0.5
+                    ):
                         # 0.5 is ok, too big will get much fewer "Extended circular" ones.
-                        if contig_name(the_better_one(link_pair[end], contig)) not in self_circular:
-                            contig2join[end].append(the_better_one(link_pair[end], contig))
+                        if (
+                            contig_name(the_better_one(link_pair[end], contig))
+                            not in self_circular
+                        ):
+                            contig2join[end].append(
+                                the_better_one(link_pair[end], contig)
+                            )
                             contig_checked[end].append(contig_name((link_pair[end][0])))
                             contig_checked[end].append(contig_name((link_pair[end][1])))
-                            contig2join_reason[contig][contig_name(the_better_one(link_pair[end], contig))] = 'the_better_one'
+                            contig2join_reason[contig][
+                                contig_name(the_better_one(link_pair[end], contig))
+                            ] = "the_better_one"
                         else:
                             pass
                     else:
@@ -341,45 +476,88 @@ def join_walker(contig, direction):
         target = get_target(contig2join[end][-1])
         if target in one_path_end:
             if not_checked(link_pair[target], contig_checked[end]):
-                if other_end_is_extendable(link_pair[target][0], contig) and (target, link_pair[target][0]) in parsed_linkage \
-                        and contig_name(link_pair[target][0]) not in self_circular:
+                if (
+                    other_end_is_extendable(link_pair[target][0], contig)
+                    and (target, link_pair[target][0]) in parsed_linkage
+                    and contig_name(link_pair[target][0]) not in self_circular
+                ):
                     contig2join[end].append(link_pair[target][0])
                     contig_checked[end].append(contig_name(link_pair[target][0]))
-                    contig2join_reason[contig][contig_name(link_pair[target][0])] = 'other_end_is_extendable'
-                elif is_ok_to_add(link_pair[target][0], contig) and (target, link_pair[target][0]) in parsed_linkage \
-                        and contig_name(link_pair[target][0]) not in self_circular:
+                    contig2join_reason[contig][
+                        contig_name(link_pair[target][0])
+                    ] = "other_end_is_extendable"
+                elif (
+                    is_ok_to_add(link_pair[target][0], contig)
+                    and (target, link_pair[target][0]) in parsed_linkage
+                    and contig_name(link_pair[target][0]) not in self_circular
+                ):
                     contig2join[end].append(link_pair[target][0])
                     contig_checked[end].append(contig_name(link_pair[target][0]))
-                    contig2join_reason[contig][contig_name(link_pair[target][0])] = 'is_ok_to_add'
+                    contig2join_reason[contig][
+                        contig_name(link_pair[target][0])
+                    ] = "is_ok_to_add"
                 else:
                     pass
             else:
                 if could_circulate(target, contig, direction):
                     path_circular.add(contig)
-                    path_circular_end.add(contig + '_' + direction)
-                    contig2join_reason[contig][contig_name(target)] = 'could_circulate'
+                    path_circular_end.add(contig + "_" + direction)
+                    contig2join_reason[contig][contig_name(target)] = "could_circulate"
         elif target in two_paths_end:
-            if link_pair[target][0].rsplit('_', 1)[0] != link_pair[target][1].rsplit('_', 1)[0]:
+            if (
+                link_pair[target][0].rsplit("_", 1)[0]
+                != link_pair[target][1].rsplit("_", 1)[0]
+            ):
                 if cov[contig_name(target)] >= 1.9 * cov[contig]:
                     pass
                 else:
                     if not_checked(link_pair[target], contig_checked[end]):
                         if are_equal_paths(link_pair[target]):
-                            if contig_name(the_dominant_one(link_pair[target])) not in self_circular:
-                                contig2join[end].append(the_dominant_one(link_pair[target]))
-                                contig_checked[end].append(contig_name(link_pair[target][0]))
-                                contig_checked[end].append(contig_name(link_pair[target][1]))
-                                contig2join_reason[contig][contig_name(the_dominant_one(link_pair[target]))] = 'are_equal_paths'
+                            if (
+                                contig_name(the_dominant_one(link_pair[target]))
+                                not in self_circular
+                            ):
+                                contig2join[end].append(
+                                    the_dominant_one(link_pair[target])
+                                )
+                                contig_checked[end].append(
+                                    contig_name(link_pair[target][0])
+                                )
+                                contig_checked[end].append(
+                                    contig_name(link_pair[target][1])
+                                )
+                                contig2join_reason[contig][
+                                    contig_name(the_dominant_one(link_pair[target]))
+                                ] = "are_equal_paths"
                             else:
                                 pass
                         else:
-                            if cov[contig_name(link_pair[target][0])] + cov[contig_name(link_pair[target][1])] >= cov[contig] * 0.5:
+                            if (
+                                cov[contig_name(link_pair[target][0])]
+                                + cov[contig_name(link_pair[target][1])]
+                                >= cov[contig] * 0.5
+                            ):
                                 # 0.5 is ok, too big will get much fewer "Extended circular" ones.
-                                if contig_name(the_better_one(link_pair[target], contig)) not in self_circular:
-                                    contig2join[end].append(the_better_one(link_pair[target], contig))
-                                    contig_checked[end].append(contig_name((link_pair[target][0])))
-                                    contig_checked[end].append(contig_name((link_pair[target][1])))
-                                    contig2join_reason[contig][contig_name(the_better_one(link_pair[target], contig))] = 'the_better_one'
+                                if (
+                                    contig_name(
+                                        the_better_one(link_pair[target], contig)
+                                    )
+                                    not in self_circular
+                                ):
+                                    contig2join[end].append(
+                                        the_better_one(link_pair[target], contig)
+                                    )
+                                    contig_checked[end].append(
+                                        contig_name((link_pair[target][0]))
+                                    )
+                                    contig_checked[end].append(
+                                        contig_name((link_pair[target][1]))
+                                    )
+                                    contig2join_reason[contig][
+                                        contig_name(
+                                            the_better_one(link_pair[target], contig)
+                                        )
+                                    ] = "the_better_one"
                                 else:
                                     pass
                             else:
@@ -387,8 +565,10 @@ def join_walker(contig, direction):
                     else:
                         if could_circulate(target, contig, direction):
                             path_circular.add(contig)
-                            path_circular_end.add(contig + '_' + direction)
-                            contig2join_reason[contig][contig_name(target)] = 'could_circulate'
+                            path_circular_end.add(contig + "_" + direction)
+                            contig2join_reason[contig][
+                                contig_name(target)
+                            ] = "could_circulate"
                         else:
                             pass
             else:
@@ -407,49 +587,69 @@ def join_seqs(contig):
     global order_all, added_to_contig
 
     order_all[contig] = []
-    left = contig + '_L'
-    right = contig + '_R'
+    left = contig + "_L"
+    right = contig + "_R"
     added_to_contig[contig] = []
 
     if contig not in path_circular:
         if left in contig2join.keys() and right in contig2join.keys():
-            for item in contig2join[left][::-1]:  # the order of contigs added into the left direction should be reversed
+            for item in contig2join[left][
+                ::-1
+            ]:  # the order of contigs added into the left direction should be reversed
                 order_all[contig].append(item)
                 added_to_contig[contig].append(contig_name(item))
 
-            order_all[contig].append(contig)  # the query contig itself should be added to the path as well
+            order_all[contig].append(
+                contig
+            )  # the query contig itself should be added to the path as well
 
             for item in contig2join[right]:
                 if contig_name(item) not in added_to_contig[contig]:
                     order_all[contig].append(item)
 
         elif left in contig2join.keys() and right not in contig2join.keys():
-            for item in contig2join[left][::-1]:  # the order of contigs added into the left direction should be reversed
+            for item in contig2join[left][
+                ::-1
+            ]:  # the order of contigs added into the left direction should be reversed
                 order_all[contig].append(item)
 
-            order_all[contig].append(contig)  # the query contig itself should be added to the path as well
+            order_all[contig].append(
+                contig
+            )  # the query contig itself should be added to the path as well
 
         else:
-            order_all[contig].append(contig)  # the query contig itself should be added to the path as well
+            order_all[contig].append(
+                contig
+            )  # the query contig itself should be added to the path as well
 
             for item in contig2join[right]:
                 order_all[contig].append(item)
 
     else:
         if left in path_circular_end and right in path_circular_end:
-            for item in contig2join[left][::-1]:  # the order of contigs added into the left direction should be reversed
+            for item in contig2join[left][
+                ::-1
+            ]:  # the order of contigs added into the left direction should be reversed
                 order_all[contig].append(item)
 
-            order_all[contig].append(contig)  # the query contig itself should be added to the path as well
+            order_all[contig].append(
+                contig
+            )  # the query contig itself should be added to the path as well
 
         elif left in path_circular_end and right not in path_circular_end:
-            for item in contig2join[left][::-1]:  # the order of contigs added into the left direction should be reversed
+            for item in contig2join[left][
+                ::-1
+            ]:  # the order of contigs added into the left direction should be reversed
                 order_all[contig].append(item)
 
-            order_all[contig].append(contig)  # the query contig itself should be added to the path as well
+            order_all[contig].append(
+                contig
+            )  # the query contig itself should be added to the path as well
 
         elif right in path_circular_end and left not in path_circular_end:
-            order_all[contig].append(contig)  # the query contig itself should be added to the path as well
+            order_all[contig].append(
+                contig
+            )  # the query contig itself should be added to the path as well
 
             for item in contig2join[right]:
                 order_all[contig].append(item)
@@ -460,12 +660,12 @@ def retrieve(contig):
     to retrieve and save all the contigs in the joining path of a query
     """
     if contig in order_all.keys() and len(order_all[contig]) > 0:
-        out = open('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(contig), 'w')
+        out = open("COBRA_retrieved_for_joining/{0}_retrieved.fa".format(contig), "w")
         added = []
         for item in order_all[contig]:
             if contig_name(item) not in added:
-                out.write('>' + contig_name(item) + '\n')
-                out.write(header2seq[contig_name(item)] + '\n')
+                out.write(">" + contig_name(item) + "\n")
+                out.write(header2seq[contig_name(item)] + "\n")
                 added.append(contig_name(item))
             else:
                 pass
@@ -479,9 +679,9 @@ def count_seq(fasta_file):
     calculate the number of seqs in a fasta file
     """
     seq_num = 0
-    a = open(fasta_file, 'r')
+    a = open(fasta_file, "r")
     for line in a.readlines():
-        if line.startswith('>'):
+        if line.startswith(">"):
             seq_num += 1
     a.close()
     return seq_num
@@ -492,9 +692,9 @@ def count_len(fasta_file):
     calculate the length of sequences in a fasta file
     """
     seq_len = 0
-    a = open(fasta_file, 'r')
+    a = open(fasta_file, "r")
     for line in a.readlines():
-        if not line.startswith('>'):
+        if not line.startswith(">"):
             seq_len += len(line.strip())
     a.close()
     return seq_len
@@ -504,46 +704,76 @@ def summary_fasta(fasta_file):
     """
     summary basic information of a fasta file
     """
-    summary_file = open('{0}.summary.txt'.format(fasta_file), 'w')
-    if 'self_circular' in fasta_file:
-        summary_file_headers = ['SeqID', 'Length', 'Coverage', 'GC', 'Ns', 'DTR_length', '\n']
-        summary_file.write('\t'.join(summary_file_headers[:]))
+    summary_file = open("{0}.summary.txt".format(fasta_file), "w")
+    if "self_circular" in fasta_file:
+        summary_file_headers = [
+            "SeqID",
+            "Length",
+            "Coverage",
+            "GC",
+            "Ns",
+            "DTR_length",
+            "\n",
+        ]
+        summary_file.write("\t".join(summary_file_headers[:]))
         summary_file.flush()
     else:
-        summary_file_headers = ['SeqID', 'Length', 'Coverage', 'GC', 'Ns', '\n']
-        summary_file.write('\t'.join(summary_file_headers[:]))
+        summary_file_headers = ["SeqID", "Length", "Coverage", "GC", "Ns", "\n"]
+        summary_file.write("\t".join(summary_file_headers[:]))
         summary_file.flush()
 
-    with open('{0}'.format(fasta_file), 'r') as f:
+    with open("{0}".format(fasta_file), "r") as f:
         for record in SeqIO.parse(f, "fasta"):
             header = str(record.id).strip()
             seq = str(record.seq)
-            ns = seq.count('N')
-            if header.split('_self')[0] in self_circular:
+            ns = seq.count("N")
+            if header.split("_self")[0] in self_circular:
                 length = args.maxk - 1 if args.assembler == "idba" else args.maxk
-                sequence_stats = [header, str(len(seq)), str(cov[header.split('_self')[0]]), str(round(GC(seq), 3)), str(ns), str(length), '\n']
-                summary_file.write('\t'.join(sequence_stats[:]))
-            elif header.split('_self')[0] in self_circular_non_expected_overlap.keys():
-                sequence_stats = [header, str(len(seq)), str(cov[header.split('_self')[0]]), str(round(GC(seq), 3)), str(ns),
-                                  str(self_circular_non_expected_overlap[header.split('_self')[0]]), '\n']
-                summary_file.write('\t'.join(sequence_stats[:]))
+                sequence_stats = [
+                    header,
+                    str(len(seq)),
+                    str(cov[header.split("_self")[0]]),
+                    str(round(GC(seq), 3)),
+                    str(ns),
+                    str(length),
+                    "\n",
+                ]
+                summary_file.write("\t".join(sequence_stats[:]))
+            elif header.split("_self")[0] in self_circular_non_expected_overlap.keys():
+                sequence_stats = [
+                    header,
+                    str(len(seq)),
+                    str(cov[header.split("_self")[0]]),
+                    str(round(GC(seq), 3)),
+                    str(ns),
+                    str(self_circular_non_expected_overlap[header.split("_self")[0]]),
+                    "\n",
+                ]
+                summary_file.write("\t".join(sequence_stats[:]))
             else:
-                sequence_stats = [header, str(len(seq)), str(cov[header.split('_extended')[0]]), str(round(GC(seq), 3)), str(ns), '\n']
-                summary_file.write('\t'.join(sequence_stats[:]))
+                sequence_stats = [
+                    header,
+                    str(len(seq)),
+                    str(cov[header.split("_extended")[0]]),
+                    str(round(GC(seq), 3)),
+                    str(ns),
+                    "\n",
+                ]
+                summary_file.write("\t".join(sequence_stats[:]))
     f.close()
 
 
 def get_joined_seqs(fasta_file):
     joined_seqs = []
-    a = open(fasta_file, 'r')
+    a = open(fasta_file, "r")
     for line in a.readlines():
-        if line.startswith('>'):
-            joined_seqs.append(line.strip().split(' ')[0][1:])
+        if line.startswith(">"):
+            joined_seqs.append(line.strip().split(" ")[0][1:])
         else:
             pass
     for item in joined_seqs:
         all_joined_query.add(item)
-    return ','.join(joined_seqs[:])
+    return ",".join(joined_seqs[:])
 
 
 def summarize(contig):
@@ -551,45 +781,123 @@ def summarize(contig):
     summary the retrieved contigs and joined information of each query
     """
     if contig not in is_subset_of.keys():
-        b = count_seq('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(contig))  # number of retrieved contigs
-        c = count_len('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(contig))  # total length of retrieved contigs
-        d = count_len('COBRA_retrieved_for_joining/{0}_retrieved_joined.fa'.format(contig))  # total length after joining
-        e = get_joined_seqs('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(contig))
+        b = count_seq(
+            "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(contig)
+        )  # number of retrieved contigs
+        c = count_len(
+            "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(contig)
+        )  # total length of retrieved contigs
+        d = count_len(
+            "COBRA_retrieved_for_joining/{0}_retrieved_joined.fa".format(contig)
+        )  # total length after joining
+        e = get_joined_seqs(
+            "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(contig)
+        )
         if contig in extended_circular_query:
-            return '\t'.join([str(b), e, str(c), str(d), str(d - header2len[contig]), 'Extended_circular'])
+            return "\t".join(
+                [
+                    str(b),
+                    e,
+                    str(c),
+                    str(d),
+                    str(d - header2len[contig]),
+                    "Extended_circular",
+                ]
+            )
         elif contig in extended_partial_query:
-            return '\t'.join([str(b), e, str(c), str(d), str(d - header2len[contig]), 'Extended_partial'])
+            return "\t".join(
+                [
+                    str(b),
+                    e,
+                    str(c),
+                    str(d),
+                    str(d - header2len[contig]),
+                    "Extended_partial",
+                ]
+            )
     else:
         if is_subset_of[contig] in is_subset_of.keys():
             item = is_subset_of[is_subset_of[contig]]
-            b = count_seq('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(item))  # number of retrieved contigs
-            c = count_len('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(item))  # total length of retrieved contigs
-            d = count_len('COBRA_retrieved_for_joining/{0}_retrieved_joined.fa'.format(item))  # total length after joining
-            e = get_joined_seqs('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(item))
+            b = count_seq(
+                "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(item)
+            )  # number of retrieved contigs
+            c = count_len(
+                "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(item)
+            )  # total length of retrieved contigs
+            d = count_len(
+                "COBRA_retrieved_for_joining/{0}_retrieved_joined.fa".format(item)
+            )  # total length after joining
+            e = get_joined_seqs(
+                "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(item)
+            )
             if contig in extended_circular_query:
-                return '\t'.join([str(b), e, str(c), str(d), str(d - header2len[contig]), 'Extended_circular'])
+                return "\t".join(
+                    [
+                        str(b),
+                        e,
+                        str(c),
+                        str(d),
+                        str(d - header2len[contig]),
+                        "Extended_circular",
+                    ]
+                )
             elif contig in extended_partial_query:
-                return '\t'.join([str(b), e, str(c), str(d), str(d - header2len[contig]), 'Extended_partial'])
+                return "\t".join(
+                    [
+                        str(b),
+                        e,
+                        str(c),
+                        str(d),
+                        str(d - header2len[contig]),
+                        "Extended_partial",
+                    ]
+                )
         else:
             item = is_subset_of[contig]
-            b = count_seq('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(item))  # number of retrieved contigs
-            c = count_len('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(item))  # total length of retrieved contigs
-            d = count_len('COBRA_retrieved_for_joining/{0}_retrieved_joined.fa'.format(item))  # total length after joining
-            e = get_joined_seqs('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(item))
+            b = count_seq(
+                "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(item)
+            )  # number of retrieved contigs
+            c = count_len(
+                "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(item)
+            )  # total length of retrieved contigs
+            d = count_len(
+                "COBRA_retrieved_for_joining/{0}_retrieved_joined.fa".format(item)
+            )  # total length after joining
+            e = get_joined_seqs(
+                "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(item)
+            )
             if contig in extended_circular_query:
-                return '\t'.join([str(b), e, str(c), str(d), str(d - header2len[contig]), 'Extended_circular'])
+                return "\t".join(
+                    [
+                        str(b),
+                        e,
+                        str(c),
+                        str(d),
+                        str(d - header2len[contig]),
+                        "Extended_circular",
+                    ]
+                )
             elif contig in extended_partial_query:
-                return '\t'.join([str(b), e, str(c), str(d), str(d - header2len[contig]), 'Extended_partial'])
+                return "\t".join(
+                    [
+                        str(b),
+                        e,
+                        str(c),
+                        str(d),
+                        str(d - header2len[contig]),
+                        "Extended_partial",
+                    ]
+                )
 
 
 def get_direction(item):
     """
     get the direction in a joining path
     """
-    if item.endswith('rc'):
-        return 'reverse'
+    if item.endswith("rc"):
+        return "reverse"
     else:
-        return 'forward'
+        return "forward"
 
 
 def total_length(contig_list):
@@ -606,29 +914,29 @@ def main():
     ##
     # get information from the input files and parameters and save information
     # get the name of the query fasta file
-    if '/' in args.query:
-        query_name = '{0}'.format(args.query).rsplit('/', 1)[1]
+    if "/" in args.query:
+        query_name = "{0}".format(args.query).rsplit("/", 1)[1]
     else:
-        query_name = '{0}'.format(args.query)
+        query_name = "{0}".format(args.query)
 
     # get the name of the whole contigs fasta file
-    if '/' in args.fasta:
-        fasta_name = '{0}'.format(args.fasta).rsplit('/', 1)[1]
+    if "/" in args.fasta:
+        fasta_name = "{0}".format(args.fasta).rsplit("/", 1)[1]
     else:
-        fasta_name = '{0}'.format(args.fasta)
+        fasta_name = "{0}".format(args.fasta)
 
     # folder of output
     if not args.output:
-        working_dir = '{0}_COBRA'.format(query_name)
+        working_dir = "{0}_COBRA".format(query_name)
     else:
-        working_dir = '{0}'.format(args.output)
+        working_dir = "{0}".format(args.output)
 
     # checking if output folder exists
-    if os.path.exists('{0}'.format(working_dir)):
-        print('Output folder <{0}> exists, please check.'.format(working_dir))
+    if os.path.exists("{0}".format(working_dir)):
+        print("Output folder <{0}> exists, please check.".format(working_dir))
         exit()
     else:
-        os.mkdir('{0}'.format(working_dir))
+        os.mkdir("{0}".format(working_dir))
 
     # determine the length of overlap based on assembler and the largest kmer size
     if args.assembler == "idba":
@@ -637,51 +945,65 @@ def main():
         length = args.maxk
 
     # write input files information to log file
-    log = open('{0}/log'.format(working_dir), 'w')  # log file
-    log.write('1. INPUT INFORMATION' + '\n')
+    log = open("{0}/log".format(working_dir), "w")  # log file
+    log.write("1. INPUT INFORMATION" + "\n")
     log.flush()
 
-    if args.assembler == 'idba':
-        parameters = ['# Assembler: IDBA_UD',
-                      '# Min-kmer: ' + str(args.mink).strip(),
-                      '# Max-kmer: ' + str(args.maxk).strip(),
-                      '# Overlap length: ' + str(length) + ' bp',
-                      '# Read mapping max mismatches for contig linkage: ' + str(args.linkage_mismatch),
-                      '# Query contigs: ' + os.path.abspath(args.query),
-                      '# Whole contig set: ' + os.path.abspath(args.fasta),
-                      '# Mapping file: ' + os.path.abspath(args.mapping),
-                      '# Coverage file: ' + os.path.abspath(args.coverage),
-                      '# Output folder: ' + os.path.abspath(working_dir), '\n']
-    elif args.assembler == 'metaspades':
-        parameters = ['# Assembler: metaSPAdes',
-                      '# Min-kmer: ' + str(args.mink).strip(),
-                      '# Max-kmer: ' + str(args.maxk).strip(),
-                      '# Overlap length: ' + str(length) + ' bp',
-                      '# Read mapping max mismatches for contig linkage: ' + str(args.linkage_mismatch),
-                      '# Query contigs: ' + os.path.abspath(args.query),
-                      '# Whole contig set: ' + os.path.abspath(args.fasta),
-                      '# Mapping file: ' + os.path.abspath(args.mapping),
-                      '# Coverage file: ' + os.path.abspath(args.coverage),
-                      '# Output folder: ' + os.path.abspath(working_dir), '\n']
+    if args.assembler == "idba":
+        parameters = [
+            "# Assembler: IDBA_UD",
+            "# Min-kmer: " + str(args.mink).strip(),
+            "# Max-kmer: " + str(args.maxk).strip(),
+            "# Overlap length: " + str(length) + " bp",
+            "# Read mapping max mismatches for contig linkage: "
+            + str(args.linkage_mismatch),
+            "# Query contigs: " + os.path.abspath(args.query),
+            "# Whole contig set: " + os.path.abspath(args.fasta),
+            "# Mapping file: " + os.path.abspath(args.mapping),
+            "# Coverage file: " + os.path.abspath(args.coverage),
+            "# Output folder: " + os.path.abspath(working_dir),
+            "\n",
+        ]
+    elif args.assembler == "metaspades":
+        parameters = [
+            "# Assembler: metaSPAdes",
+            "# Min-kmer: " + str(args.mink).strip(),
+            "# Max-kmer: " + str(args.maxk).strip(),
+            "# Overlap length: " + str(length) + " bp",
+            "# Read mapping max mismatches for contig linkage: "
+            + str(args.linkage_mismatch),
+            "# Query contigs: " + os.path.abspath(args.query),
+            "# Whole contig set: " + os.path.abspath(args.fasta),
+            "# Mapping file: " + os.path.abspath(args.mapping),
+            "# Coverage file: " + os.path.abspath(args.coverage),
+            "# Output folder: " + os.path.abspath(working_dir),
+            "\n",
+        ]
     else:
-        parameters = ['# Assembler: MEGAHIT',
-                      '# Min-kmer: ' + str(args.mink).strip(),
-                      '# Max-kmer: ' + str(args.maxk).strip(),
-                      '# Overlap length: ' + str(length) + ' bp',
-                      '# Read mapping max mismatches for contig linkage: ' + str(args.linkage_mismatch),
-                      '# Query contigs: ' + os.path.abspath(args.query),
-                      '# Whole contig set: ' + os.path.abspath(args.fasta),
-                      '# Mapping file: ' + os.path.abspath(args.mapping),
-                      '# Coverage file: ' + os.path.abspath(args.coverage),
-                      '# Output folder: ' + os.path.abspath(working_dir), '\n']
+        parameters = [
+            "# Assembler: MEGAHIT",
+            "# Min-kmer: " + str(args.mink).strip(),
+            "# Max-kmer: " + str(args.maxk).strip(),
+            "# Overlap length: " + str(length) + " bp",
+            "# Read mapping max mismatches for contig linkage: "
+            + str(args.linkage_mismatch),
+            "# Query contigs: " + os.path.abspath(args.query),
+            "# Whole contig set: " + os.path.abspath(args.fasta),
+            "# Mapping file: " + os.path.abspath(args.mapping),
+            "# Coverage file: " + os.path.abspath(args.coverage),
+            "# Output folder: " + os.path.abspath(working_dir),
+            "\n",
+        ]
 
-    log.write('\n'.join(parameters[:]))
-    log.write('2. PROCESSING STEPS' + '\n')
+    log.write("\n".join(parameters[:]))
+    log.write("2. PROCESSING STEPS" + "\n")
     log.flush()
 
     ##
     # import the whole contigs and save their end sequences
-    log_info('[01/23]', 'Reading contigs and getting the contig end sequences. ', '', log)
+    log_info(
+        "[01/23]", "Reading contigs and getting the contig end sequences. ", "", log
+    )
     # header2seq = {}
     # header2len = {}
     gc = {}
@@ -690,23 +1012,29 @@ def main():
     Lrc = {}
     Rrc = {}
 
-    with open('{0}'.format(args.fasta), 'r') as f:
+    with open("{0}".format(args.fasta), "r") as f:
         for record in SeqIO.parse(f, "fasta"):
             header = str(record.id).strip()
             seq = str(record.seq)
             header2seq[header] = seq
             gc[header] = str(round(GC(seq), 3))
             header2len[header] = len(seq)
-            L[header + '_L'] = seq[0:length]  # the first x bp of left end
-            Lrc[header + '_Lrc'] = reverse_complement(seq[0:length])  # the reverse sequence of first x bp of left end
-            R[header + '_R'] = seq[-length:]  # the first x bp of right end
-            Rrc[header + '_Rrc'] = reverse_complement(seq[-length:])  # the reverse sequence of first x bp of right end
+            L[header + "_L"] = seq[0:length]  # the first x bp of left end
+            Lrc[header + "_Lrc"] = reverse_complement(
+                seq[0:length]
+            )  # the reverse sequence of first x bp of left end
+            R[header + "_R"] = seq[-length:]  # the first x bp of right end
+            Rrc[header + "_Rrc"] = reverse_complement(
+                seq[-length:]
+            )  # the reverse sequence of first x bp of right end
 
-    log.write('A total of {0} contigs were imported.'.format(len(header2seq.keys())) + '\n')
+    log.write(
+        "A total of {0} contigs were imported.".format(len(header2seq.keys())) + "\n"
+    )
 
     ##
     # get potential joins
-    log_info('[02/23]', 'Getting shared contig ends.', '\n', log)
+    log_info("[02/23]", "Getting shared contig ends.", "\n", log)
 
     # link_pair = {}  # used to save all overlaps between ends
 
@@ -791,34 +1119,45 @@ def main():
 
     ##
     # save all paired links to a file
-    log_info('[03/23]', 'Writing contig end joining pairs.', '\n', log)
+    log_info("[03/23]", "Writing contig end joining pairs.", "\n", log)
 
-    p = open('{0}/COBRA_end_joining_pairs.txt'.format(working_dir), 'w')
+    p = open("{0}/COBRA_end_joining_pairs.txt".format(working_dir), "w")
 
     for item in link_pair.keys():
         for point in link_pair[item]:
-            p.write(item + '\t' + point + '\n')  # print link pairs into a file for check if interested
+            p.write(
+                item + "\t" + point + "\n"
+            )  # print link pairs into a file for check if interested
 
         if len(link_pair[item]) == 1:  # and len(link_pair[link_pair[item][0]]) > 1:
-            one_path_end.append(item)  # add one joining end to a list, its pair may have one or more joins
-        elif len(link_pair[item]) == 2 and len(link_pair[link_pair[item][0]]) == 1 and len(
-                link_pair[link_pair[item][1]]) == 1:
-            two_paths_end.append(item)  # add two joining end to a list, each of its pairs should only have one join
+            one_path_end.append(
+                item
+            )  # add one joining end to a list, its pair may have one or more joins
+        elif (
+            len(link_pair[item]) == 2
+            and len(link_pair[link_pair[item][0]]) == 1
+            and len(link_pair[link_pair[item][1]]) == 1
+        ):
+            two_paths_end.append(
+                item
+            )  # add two joining end to a list, each of its pairs should only have one join
         else:
             pass
     p.close()
 
     ##
     # read and save the coverage of all contigs
-    log_info('[04/23]', 'Getting contig coverage information.', '\n', log)
-    coverage = open('{0}'.format(args.coverage), 'r')
+    log_info("[04/23]", "Getting contig coverage information.", "\n", log)
+    coverage = open("{0}".format(args.coverage), "r")
     for line in coverage.readlines():
-        line = line.strip().split('\t')
+        line = line.strip().split("\t")
         cov[line[0]] = round(float(line[1]), 3)
     coverage.close()
 
     if len(cov.keys()) < len(header2seq.keys()):
-        print('Some contigs do not have coverage information. Please check. COBRA exits.')
+        print(
+            "Some contigs do not have coverage information. Please check. COBRA exits."
+        )
         exit()
     else:
         pass
@@ -826,49 +1165,79 @@ def main():
     ##
     # open the query file and save the information
 
-    log_info('[05/23]', 'Getting query contig list. ', '', log)
+    log_info("[05/23]", "Getting query contig list. ", "", log)
     query_set = set()
     orphan_end_query = set()
     non_orphan_end_query = set()
 
-    with open('{0}'.format(args.query), 'r') as query_file:
-        if determine_file_format(args.query) == 'fasta':  # if the query file is in fasta format
-            for record in SeqIO.parse(query_file, 'fasta'):
+    with open("{0}".format(args.query), "r") as query_file:
+        if (
+            determine_file_format(args.query) == "fasta"
+        ):  # if the query file is in fasta format
+            for record in SeqIO.parse(query_file, "fasta"):
                 header = str(record.id).strip()
-                if header in header2seq.keys():  # some queries may not in the whole assembly, should be rare though.
+                if (
+                    header in header2seq.keys()
+                ):  # some queries may not in the whole assembly, should be rare though.
                     query_set.add(header)
                 else:
-                    print('Query {0} is not in your whole contig fasta file, please check!'.format(header), flush=True)
+                    print(
+                        "Query {0} is not in your whole contig fasta file, please check!".format(
+                            header
+                        ),
+                        flush=True,
+                    )
         else:  # if the query file is in text format
             for line in query_file:
-                header = line.strip().split(' ')[0]
-                if header in header2seq.keys():  # some queries may not in the whole assembly, should be rare though.
+                header = line.strip().split(" ")[0]
+                if (
+                    header in header2seq.keys()
+                ):  # some queries may not in the whole assembly, should be rare though.
                     query_set.add(header)
                 else:
-                    print('Query {0} is not in your whole contig fasta file, please check!'.format(header), flush=True)
+                    print(
+                        "Query {0} is not in your whole contig fasta file, please check!".format(
+                            header
+                        ),
+                        flush=True,
+                    )
 
     # distinguish orphan_end_query and non_orphan_end_query:
 
     for header in query_set:
-        if header + '_L' not in link_pair.keys() and header + '_R' not in link_pair.keys():
+        if (
+            header + "_L" not in link_pair.keys()
+            and header + "_R" not in link_pair.keys()
+        ):
             orphan_end_query.add(header)
         else:
             non_orphan_end_query.add(header)
 
     #
-    log.write('A total of {0} query contigs were imported.'.format(len(query_set)) + '\n')
+    log.write(
+        "A total of {0} query contigs were imported.".format(len(query_set)) + "\n"
+    )
     log.flush()
 
     ##
     # get the linkage of contigs based on paired-end reads mapping
-    log_info('[06/23]', 'Getting contig linkage based on sam/bam. Be patient, this may take long.', '\n', log)
+    log_info(
+        "[06/23]",
+        "Getting contig linkage based on sam/bam. Be patient, this may take long.",
+        "\n",
+        log,
+    )
     linkage = defaultdict(set)  # Initialize a defaultdict to store linked contigs
-    contig_spanned_by_PE_reads = {}  # Initialize a dictionary to store paired-end reads spanning contigs
+    contig_spanned_by_PE_reads = (
+        {}
+    )  # Initialize a dictionary to store paired-end reads spanning contigs
 
     for contig in orphan_end_query:
-        contig_spanned_by_PE_reads[contig] = defaultdict(list)  # Create a defaultdict(list) for each contig in header2seq
+        contig_spanned_by_PE_reads[contig] = defaultdict(
+            list
+        )  # Create a defaultdict(list) for each contig in header2seq
 
-    with pysam.AlignmentFile('{0}'.format(args.mapping), 'rb') as map_file:
+    with pysam.AlignmentFile("{0}".format(args.mapping), "rb") as map_file:
         for line in map_file:
             if not line.is_unmapped and line.get_tag("NM") <= args.linkage_mismatch:
                 # mismatch should not be more than the defined threshold
@@ -877,19 +1246,28 @@ def main():
                     if header2len[line.reference_name] > 1000:
                         # If the contig length is greater than 1000, determine if the read maps to the left or right end
                         if line.reference_start <= 500:
-                            linkage[line.query_name].add(line.reference_name + '_L')  # left end
+                            linkage[line.query_name].add(
+                                line.reference_name + "_L"
+                            )  # left end
                         else:
-                            linkage[line.query_name].add(line.reference_name + '_R')  # right end
+                            linkage[line.query_name].add(
+                                line.reference_name + "_R"
+                            )  # right end
                     else:
                         # If the contig length is 1000 or less, add both the left and right ends to the linkage
-                        linkage[line.query_name].add(line.reference_name + '_L')
-                        linkage[line.query_name].add(line.reference_name + '_R')
+                        linkage[line.query_name].add(line.reference_name + "_L")
+                        linkage[line.query_name].add(line.reference_name + "_R")
                 else:
                     # If the read and its mate map to the same contig, store the read mapped position (start)
                     if line.reference_name in orphan_end_query:
-                        if line.reference_start <= 500 or header2len[line.reference_name] - line.reference_start <= 500:
-                            contig_spanned_by_PE_reads[line.reference_name][line.query_name].append(
-                                line.reference_start)
+                        if (
+                            line.reference_start <= 500
+                            or header2len[line.reference_name] - line.reference_start
+                            <= 500
+                        ):
+                            contig_spanned_by_PE_reads[line.reference_name][
+                                line.query_name
+                            ].append(line.reference_start)
                         else:
                             pass
                     else:
@@ -898,39 +1276,48 @@ def main():
                 pass
 
     #
-    log_info('[07/23]', 'Parsing the linkage information.', '\n', log)
+    log_info("[07/23]", "Parsing the linkage information.", "\n", log)
 
     for read in linkage.keys():
         if len(linkage[read]) >= 2:  # Process only reads linked to at least two contigs
             # for item in linkage[read]:
             for item, item_1 in itertools.combinations(linkage[read], 2):
                 # Generate unique pairs of linked contigs for the current read using itertools.combinations
-                if item.rsplit('_', 1)[1] != item_1.rsplit('_', 1)[1]:
+                if item.rsplit("_", 1)[1] != item_1.rsplit("_", 1)[1]:
                     # If the contigs have different ends (_L or _R), add the combinations to the parsed_linkage
                     parsed_linkage.add((item, item_1))
                     parsed_linkage.add((item_1, item))
-                    parsed_linkage.add((item + 'rc', item_1 + 'rc'))
-                    parsed_linkage.add((item_1 + 'rc', item + 'rc'))
+                    parsed_linkage.add((item + "rc", item_1 + "rc"))
+                    parsed_linkage.add((item_1 + "rc", item + "rc"))
                 else:
                     # If the contigs have the same ends, add the combinations with reverse-complement (_rc) to the parsed_linkage
-                    parsed_linkage.add((item, item_1 + 'rc'))
-                    parsed_linkage.add((item_1 + 'rc', item))
-                    parsed_linkage.add((item + 'rc', item_1))
-                    parsed_linkage.add((item_1, item + 'rc'))
+                    parsed_linkage.add((item, item_1 + "rc"))
+                    parsed_linkage.add((item_1 + "rc", item))
+                    parsed_linkage.add((item + "rc", item_1))
+                    parsed_linkage.add((item_1, item + "rc"))
         else:
             pass
 
     linkage = None  # remove it as no longer used later
 
     #
-    parsed_contig_spanned_by_PE_reads = set()  # Initialize a set to store the contig spanned by paired-end reads
+    parsed_contig_spanned_by_PE_reads = (
+        set()
+    )  # Initialize a set to store the contig spanned by paired-end reads
     for contig in orphan_end_query:
-        for PE in contig_spanned_by_PE_reads[contig].keys():  # Check if the count is 0 and the contig has exactly two paired-end reads
+        for PE in contig_spanned_by_PE_reads[
+            contig
+        ].keys():  # Check if the count is 0 and the contig has exactly two paired-end reads
             if len(contig_spanned_by_PE_reads[contig][PE]) == 2:
                 # Check if the absolute difference between the positions of the two paired-end reads is greater than or equal to
                 # the length of contig minus 1000 bp
-                if abs(contig_spanned_by_PE_reads[contig][PE][0] - contig_spanned_by_PE_reads[contig][PE][1]) >= \
-                        header2len[contig] - 1000:
+                if (
+                    abs(
+                        contig_spanned_by_PE_reads[contig][PE][0]
+                        - contig_spanned_by_PE_reads[contig][PE][1]
+                    )
+                    >= header2len[contig] - 1000
+                ):
                     parsed_contig_spanned_by_PE_reads.add(contig)
                 else:
                     pass
@@ -939,27 +1326,31 @@ def main():
 
     ##
     #
-    log_info('[08/23]', 'Detecting self_circular contigs. ', '\n', log)
+    log_info("[08/23]", "Detecting self_circular contigs. ", "\n", log)
 
     for contig in non_orphan_end_query:
         detect_self_circular(contig)
 
-    debug = open('{0}/debug.txt'.format(working_dir), 'w')
+    debug = open("{0}/debug.txt".format(working_dir), "w")
 
     # for debug
-    print('self_circular', file=debug, flush=True)
+    print("self_circular", file=debug, flush=True)
     print(self_circular, file=debug, flush=True)
 
     # orphan end queries info
     # determine potential self_circular contigs from contigs with orphan end
 
     min_over_len = 0
-    if args.assembler == 'idba':
+    if args.assembler == "idba":
         min_over_len = args.mink - 1
     else:
         min_over_len = args.mink
 
-    for contig in orphan_end_query:  # determine if there is DTR for those query with orphan ends, if yes, assign as self_circular as well
+    for (
+        contig
+    ) in (
+        orphan_end_query
+    ):  # determine if there is DTR for those query with orphan ends, if yes, assign as self_circular as well
         if contig in parsed_contig_spanned_by_PE_reads:
             sequence = header2seq[contig]
             end_part = sequence[-min_over_len:]
@@ -982,15 +1373,15 @@ def main():
 
     ##
     # walk the joins
-    log_info('[09/23]', 'Detecting joins of contigs. ', '', log)
+    log_info("[09/23]", "Detecting joins of contigs. ", "", log)
 
     for contig in query_set:
-        contig2join[contig + '_L'] = []
-        contig2join[contig + '_R'] = []
-        contig_checked[contig + '_L'] = []
-        contig_checked[contig + '_R'] = []
+        contig2join[contig + "_L"] = []
+        contig2join[contig + "_R"] = []
+        contig_checked[contig + "_L"] = []
+        contig_checked[contig + "_R"] = []
         contig2join_reason[contig] = {}
-        contig2join_reason[contig][contig] = 'query'
+        contig2join_reason[contig][contig] = "query"
 
     percentage = [10, 20, 30, 40, 50, 60, 70, 80, 90]
     finished_join_walker = 0
@@ -1002,12 +1393,12 @@ def main():
 
             # extend each contig from both directions
             while True:
-                result_L = join_walker(contig, 'L')
+                result_L = join_walker(contig, "L")
                 if not result_L:
                     break
 
             while True:
-                result_R = join_walker(contig, 'R')
+                result_R = join_walker(contig, "R")
                 if not result_R:
                     break
 
@@ -1016,7 +1407,7 @@ def main():
             finished_percentage = int(finished_join_walker / total_join_walker * 100)
 
             if finished_percentage in percentage:
-                log.write(str(finished_percentage) + '%, ')
+                log.write(str(finished_percentage) + "%, ")
                 log.flush()
                 percentage.remove(finished_percentage)
             else:
@@ -1027,31 +1418,45 @@ def main():
 
     ##
     # save the potential joining paths
-    log.write('100% finished.' + '\n')
-    log_info('[10/23]', 'Saving potential joining paths.', '\n', log)
+    log.write("100% finished." + "\n")
+    log_info("[10/23]", "Saving potential joining paths.", "\n", log)
 
-    with open('{0}/COBRA_potential_joining_paths.txt'.format(working_dir), 'w') as results:
+    with open(
+        "{0}/COBRA_potential_joining_paths.txt".format(working_dir), "w"
+    ) as results:
         for item in contig2join.keys():
             if contig_name(item) in self_circular:
-                if item.endswith('_L'):
-                    results.write(item + '\t' + "['" + contig_name(item) + '_R' + "']" + '\n')
+                if item.endswith("_L"):
+                    results.write(
+                        item + "\t" + "['" + contig_name(item) + "_R" + "']" + "\n"
+                    )
                     results.flush()
                 else:
-                    results.write(item + '\t' + "['" + contig_name(item) + '_L' + "']" + '\n')
+                    results.write(
+                        item + "\t" + "['" + contig_name(item) + "_L" + "']" + "\n"
+                    )
                     results.flush()
             else:
-                results.write(item + '\t' + str(contig2join[item]) + '\n')
+                results.write(item + "\t" + str(contig2join[item]) + "\n")
                 results.flush()
 
     ##
     # get the fail_to_join contigs, but not due to orphan end
     failed_join_list = []
     for contig in query_set:
-        if contig + '_L' in link_pair.keys() or contig + '_R' in link_pair.keys():
-            if len(contig2join[contig + '_L']) == 0 and len(contig2join[contig + '_R']) == 0 \
-                    and contig not in self_circular:
+        if contig + "_L" in link_pair.keys() or contig + "_R" in link_pair.keys():
+            if (
+                len(contig2join[contig + "_L"]) == 0
+                and len(contig2join[contig + "_R"]) == 0
+                and contig not in self_circular
+            ):
                 failed_join_list.append(contig)
-                print(contig, len(contig2join[contig + '_L']), len(contig2join[contig + '_R']), contig not in self_circular)
+                print(
+                    contig,
+                    len(contig2join[contig + "_L"]),
+                    len(contig2join[contig + "_R"]),
+                    contig not in self_circular,
+                )
             else:
                 pass
         else:
@@ -1059,27 +1464,33 @@ def main():
 
     ##
     # get the joining paths
-    log_info('[11/23]', 'Checking for invalid joining: sharing queries.', '\n', log)
+    log_info("[11/23]", "Checking for invalid joining: sharing queries.", "\n", log)
     contig2assembly = {}
     for item in contig2join.keys():
         contig = contig_name(item)
-        if contig + '_L' in path_circular_end and contig + '_R' not in path_circular_end:
+        if (
+            contig + "_L" in path_circular_end
+            and contig + "_R" not in path_circular_end
+        ):
             if contig not in contig2assembly.keys():
                 contig2assembly[contig] = set()
                 contig2assembly[contig].add(contig)
-                for point in contig2join[contig + '_L']:
+                for point in contig2join[contig + "_L"]:
                     contig2assembly[contig].add(contig_name(point))
             else:
-                for point in contig2join[contig + '_L']:
+                for point in contig2join[contig + "_L"]:
                     contig2assembly[contig].add(contig_name(point))
-        elif contig + '_L' not in path_circular_end and contig + '_R' in path_circular_end:
+        elif (
+            contig + "_L" not in path_circular_end
+            and contig + "_R" in path_circular_end
+        ):
             if contig not in contig2assembly.keys():
                 contig2assembly[contig] = set()
                 contig2assembly[contig].add(contig)
-                for point in contig2join[contig + '_R']:
+                for point in contig2join[contig + "_R"]:
                     contig2assembly[contig].add(contig_name(point))
             else:
-                for point in contig2join[contig + '_R']:
+                for point in contig2join[contig + "_R"]:
                     contig2assembly[contig].add(contig_name(point))
         else:
             if contig not in contig2assembly.keys():
@@ -1092,11 +1503,11 @@ def main():
                     contig2assembly[contig].add(contig_name(point))
 
     # for debug
-    print('path_circular', file=debug, flush=True)
+    print("path_circular", file=debug, flush=True)
     print(path_circular, file=debug, flush=True)
-    print('1failed_join_list', file=debug, flush=True)
+    print("1failed_join_list", file=debug, flush=True)
     print(failed_join_list, file=debug, flush=True)
-    print('contig2assembly', file=debug, flush=True)
+    print("contig2assembly", file=debug, flush=True)
     print(contig2assembly, file=debug, flush=True)
 
     ##
@@ -1105,7 +1516,9 @@ def main():
     is_same_as = {}
     for contig in contig2assembly.keys():
         for contig_1 in contig2assembly.keys():
-            if contig != contig_1 and contig2assembly[contig].issubset(contig2assembly[contig_1]):
+            if contig != contig_1 and contig2assembly[contig].issubset(
+                contig2assembly[contig_1]
+            ):
                 if contig2assembly[contig] != contig2assembly[contig_1]:
                     if contig in path_circular and contig_1 not in path_circular:
                         # in this rare case, should use contig, not contig_1, thus contig_1 is_subset_of contig
@@ -1152,7 +1565,7 @@ def main():
                 pass
 
     # for debug
-    print('2failed_join_list', file=debug, flush=True)
+    print("2failed_join_list", file=debug, flush=True)
     print(failed_join_list, file=debug, flush=True)
 
     for contig in is_subset_of.keys():
@@ -1160,7 +1573,7 @@ def main():
             failed_join_list.append(contig)
 
     # for debug
-    print('3failed_join_list', file=debug, flush=True)
+    print("3failed_join_list", file=debug, flush=True)
     print(failed_join_list, file=debug, flush=True)
 
     ##
@@ -1184,7 +1597,7 @@ def main():
             pass
 
     # for debug
-    print('same_path', file=debug, flush=True)
+    print("same_path", file=debug, flush=True)
     print(same_path, file=debug, flush=True)
 
     for contig in set(all):
@@ -1201,7 +1614,7 @@ def main():
             pass
 
     # for debug
-    print('contig_shared_by_paths', file=debug, flush=True)
+    print("contig_shared_by_paths", file=debug, flush=True)
     print(contig_shared_by_paths, file=debug, flush=True)
 
     for contig in contig_shared_by_paths:
@@ -1212,7 +1625,7 @@ def main():
             pass
 
     # for debug
-    print('4failed_join_list', file=debug, flush=True)
+    print("4failed_join_list", file=debug, flush=True)
     print(failed_join_list, file=debug, flush=True)
 
     for contig in contig_shared_by_paths:
@@ -1229,12 +1642,14 @@ def main():
                 pass
 
     # for debug
-    print('5failed_join_list', file=debug, flush=True)
+    print("5failed_join_list", file=debug, flush=True)
     print(failed_join_list, file=debug, flush=True)
 
     ##
     # determine the joining status of queries
-    log_info('[12/23]', 'Getting initial joining status of each query contig.', '\n', log)
+    log_info(
+        "[12/23]", "Getting initial joining status of each query contig.", "\n", log
+    )
 
     for contig in contig2assembly.keys():
         if contig not in failed_join_list:
@@ -1247,8 +1662,12 @@ def main():
                 if contig in path_circular:
                     extended_circular_query.add(contig)
                 else:
-                    if contig not in failed_join_list and contig not in orphan_end_query and contig not in self_circular \
-                            and contig not in self_circular_non_expected_overlap.keys():
+                    if (
+                        contig not in failed_join_list
+                        and contig not in orphan_end_query
+                        and contig not in self_circular
+                        and contig not in self_circular_non_expected_overlap.keys()
+                    ):
                         extended_partial_query.add(contig)
                     else:
                         pass
@@ -1256,17 +1675,23 @@ def main():
             pass
 
     # for debug
-    print('6failed_join_list', file=debug, flush=True)
+    print("6failed_join_list", file=debug, flush=True)
     print(failed_join_list, file=debug, flush=True)
 
     ##
     # deal with cross-assignment queries
-    log_info('[13/23]', 'Getting final joining status of each query contig.', '\n', log)
+    log_info("[13/23]", "Getting final joining status of each query contig.", "\n", log)
     for contig in failed_join_list:
-        if contig in is_subset_of.keys() and is_subset_of[contig] in extended_circular_query:
+        if (
+            contig in is_subset_of.keys()
+            and is_subset_of[contig] in extended_circular_query
+        ):
             failed_join_list.remove(contig)
             extended_circular_query.add(contig)
-        elif contig in is_subset_of.keys() and is_subset_of[contig] in extended_partial_query:
+        elif (
+            contig in is_subset_of.keys()
+            and is_subset_of[contig] in extended_partial_query
+        ):
             failed_join_list.remove(contig)
             extended_partial_query.add(contig)
         elif contig in is_same_as.keys():
@@ -1320,17 +1745,17 @@ def main():
             pass
 
     # for debug
-    print('7failed_join_list', file=debug, flush=True)
+    print("7failed_join_list", file=debug, flush=True)
     print(failed_join_list, file=debug, flush=True)
 
     # for debug
-    print('path_circular', file=debug, flush=True)
+    print("path_circular", file=debug, flush=True)
     print(path_circular, file=debug, flush=True)
-    print('redundant', file=debug, flush=True)
+    print("redundant", file=debug, flush=True)
     print(redundant, file=debug, flush=True)
-    print('is_subset_of', file=debug, flush=True)
+    print("is_subset_of", file=debug, flush=True)
     print(is_subset_of, file=debug, flush=True)
-    print('is_same_as', file=debug, flush=True)
+    print("is_same_as", file=debug, flush=True)
     print(is_same_as, file=debug, flush=True)
 
     #
@@ -1345,7 +1770,7 @@ def main():
 
     ##
     # get the joining order of contigs
-    log_info('[14/23]', 'Getting the joining order of contigs.', '\n', log)
+    log_info("[14/23]", "Getting the joining order of contigs.", "\n", log)
     # order_all = {}
     # added_to_contig = {}
 
@@ -1353,7 +1778,11 @@ def main():
         # only those contigs left in contig2assembly after filtering
         # (see above "# remove the queries in multiple paths") will be
         # checked for join paths (join_seqs) to get order_all
-        if len(contig2assembly[contig]) > 1 and contig not in failed_join_list and contig not in redundant:
+        if (
+            len(contig2assembly[contig]) > 1
+            and contig not in failed_join_list
+            and contig not in redundant
+        ):
             if all_contigs_in_the_path_are_good(contig2assembly[contig]):
                 join_seqs(contig)
             else:
@@ -1371,119 +1800,164 @@ def main():
 
     ##
     # get retrieved sequences
-    log_info('[15/23]', 'Getting retrieved contigs.', '\n', log)
-    os.chdir('{0}'.format(working_dir))
-    os.mkdir('COBRA_retrieved_for_joining')
+    log_info("[15/23]", "Getting retrieved contigs.", "\n", log)
+    os.chdir("{0}".format(working_dir))
+    os.mkdir("COBRA_retrieved_for_joining")
     retrieved = []
     for contig in order_all.keys():
         retrieve(contig)
         retrieved.append(contig)
 
     # for debug
-    print('retrieved', file=debug, flush=True)
+    print("retrieved", file=debug, flush=True)
     print(retrieved, file=debug, flush=True)
 
     ##
     # writing joined sequences
-    log_info('[16/23]', 'Saving joined seqeuences.', '\n', log)
+    log_info("[16/23]", "Saving joined seqeuences.", "\n", log)
     header2joined_seq = {}
     contig2extended_status = {}
     for contig in retrieved:
-        a = open('COBRA_retrieved_for_joining/{0}_retrieved_joined.fa'.format(contig), 'w')
-        last = ''
+        a = open(
+            "COBRA_retrieved_for_joining/{0}_retrieved_joined.fa".format(contig), "w"
+        )
+        last = ""
         # print header regarding the joining status
         if contig in path_circular:
-            a.write('>' + contig + '_extended_circular' + '\n')
-            header2joined_seq[contig + '_extended_circular'] = ''
-            contig2extended_status[contig] = contig + '_extended_circular'
+            a.write(">" + contig + "_extended_circular" + "\n")
+            header2joined_seq[contig + "_extended_circular"] = ""
+            contig2extended_status[contig] = contig + "_extended_circular"
         else:
-            a.write('>' + contig + '_extended_partial' + '\n')
-            header2joined_seq[contig + '_extended_partial'] = ''
-            contig2extended_status[contig] = contig + '_extended_partial'
+            a.write(">" + contig + "_extended_partial" + "\n")
+            header2joined_seq[contig + "_extended_partial"] = ""
+            contig2extended_status[contig] = contig + "_extended_partial"
 
         # print the sequences with their overlap removed
         for item in order_all[contig][:-1]:
-            if item.endswith('_R') or item.endswith('_L'):
-                if last == '':
-                    a.write(header2seq[item.rsplit('_', 1)[0]][:-length])
-                    last = header2seq[item.rsplit('_', 1)[0]][-length:]
-                    header2joined_seq[contig2extended_status[contig]] += header2seq[item.rsplit('_', 1)[0]][:-length]
+            if item.endswith("_R") or item.endswith("_L"):
+                if last == "":
+                    a.write(header2seq[item.rsplit("_", 1)[0]][:-length])
+                    last = header2seq[item.rsplit("_", 1)[0]][-length:]
+                    header2joined_seq[contig2extended_status[contig]] += header2seq[
+                        item.rsplit("_", 1)[0]
+                    ][:-length]
                 else:
-                    if header2seq[item.rsplit('_', 1)[0]][:length] == last:
-                        a.write(header2seq[item.rsplit('_', 1)[0]][:-length])
-                        last = header2seq[item.rsplit('_', 1)[0]][-length:]
-                        header2joined_seq[contig2extended_status[contig]] += header2seq[item.rsplit('_', 1)[0]][
-                                                                             :-length]
+                    if header2seq[item.rsplit("_", 1)[0]][:length] == last:
+                        a.write(header2seq[item.rsplit("_", 1)[0]][:-length])
+                        last = header2seq[item.rsplit("_", 1)[0]][-length:]
+                        header2joined_seq[contig2extended_status[contig]] += header2seq[
+                            item.rsplit("_", 1)[0]
+                        ][:-length]
                     else:
                         pass
-            elif item.endswith('rc'):
-                if last == '':
-                    a.write(reverse_complement(header2seq[item.rsplit('_', 1)[0]])[:-length])
-                    last = reverse_complement(header2seq[item.rsplit('_', 1)[0]])[-length:]
-                    header2joined_seq[contig2extended_status[contig]] += reverse_complement(
-                        header2seq[item.rsplit('_', 1)[0]])[:-length]
+            elif item.endswith("rc"):
+                if last == "":
+                    a.write(
+                        reverse_complement(header2seq[item.rsplit("_", 1)[0]])[:-length]
+                    )
+                    last = reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                        -length:
+                    ]
+                    header2joined_seq[
+                        contig2extended_status[contig]
+                    ] += reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                        :-length
+                    ]
                 else:
-                    if reverse_complement(header2seq[item.rsplit('_', 1)[0]])[:length] == last:
-                        a.write(reverse_complement(header2seq[item.rsplit('_', 1)[0]])[:-length])
-                        last = reverse_complement(header2seq[item.rsplit('_', 1)[0]])[-length:]
-                        header2joined_seq[contig2extended_status[contig]] += reverse_complement(
-                            header2seq[item.rsplit('_', 1)[0]])[:-length]
+                    if (
+                        reverse_complement(header2seq[item.rsplit("_", 1)[0]])[:length]
+                        == last
+                    ):
+                        a.write(
+                            reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                                :-length
+                            ]
+                        )
+                        last = reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                            -length:
+                        ]
+                        header2joined_seq[
+                            contig2extended_status[contig]
+                        ] += reverse_complement(header2seq[item.rsplit("_", 1)[0]])[
+                            :-length
+                        ]
                     else:
                         pass
             else:
-                if last == '':
+                if last == "":
                     a.write(header2seq[contig][:-length])
                     last = header2seq[contig][-length:]
-                    header2joined_seq[contig2extended_status[contig]] += header2seq[contig][:-length]
+                    header2joined_seq[contig2extended_status[contig]] += header2seq[
+                        contig
+                    ][:-length]
                 else:
                     if header2seq[contig][:length] == last:
                         a.write(header2seq[contig][:-length])
                         last = header2seq[contig][-length:]
-                        header2joined_seq[contig2extended_status[contig]] += header2seq[contig][:-length]
+                        header2joined_seq[contig2extended_status[contig]] += header2seq[
+                            contig
+                        ][:-length]
                     else:
                         pass
 
-        if order_all[contig][-1].endswith('rc'):
-            a.write(reverse_complement(header2seq[order_all[contig][-1].rsplit('_', 1)[0]]) + '\n')
+        if order_all[contig][-1].endswith("rc"):
+            a.write(
+                reverse_complement(header2seq[order_all[contig][-1].rsplit("_", 1)[0]])
+                + "\n"
+            )
             header2joined_seq[contig2extended_status[contig]] += reverse_complement(
-                header2seq[order_all[contig][-1].rsplit('_', 1)[0]])
-        elif order_all[contig][-1].endswith('_R') or order_all[contig][-1].endswith('_L'):
-            a.write(header2seq[order_all[contig][-1].rsplit('_', 1)[0]] + '\n')
-            header2joined_seq[contig2extended_status[contig]] += header2seq[order_all[contig][-1].rsplit('_', 1)[0]]
+                header2seq[order_all[contig][-1].rsplit("_", 1)[0]]
+            )
+        elif order_all[contig][-1].endswith("_R") or order_all[contig][-1].endswith(
+            "_L"
+        ):
+            a.write(header2seq[order_all[contig][-1].rsplit("_", 1)[0]] + "\n")
+            header2joined_seq[contig2extended_status[contig]] += header2seq[
+                order_all[contig][-1].rsplit("_", 1)[0]
+            ]
         else:
-            a.write(header2seq[order_all[contig][-1]] + '\n')
-            header2joined_seq[contig2extended_status[contig]] += header2seq[order_all[contig][-1]]
+            a.write(header2seq[order_all[contig][-1]] + "\n")
+            header2joined_seq[contig2extended_status[contig]] += header2seq[
+                order_all[contig][-1]
+            ]
 
         a.close()
 
-    print('contig2extended_status', file=debug, flush=True)
+    print("contig2extended_status", file=debug, flush=True)
     print(contig2extended_status, file=debug, flush=True)
-    print('header2joined_seq', file=debug, flush=True)
+    print("header2joined_seq", file=debug, flush=True)
     print(header2joined_seq.keys(), file=debug, flush=True)
 
     ##
     # Similar direct terminal repeats may lead to invalid joins
-    log_info('[17/23]', 'Checking for invalid joining using BLASTn: close strains.', '\n', log)
-    blastdb_1 = open('blastdb_1.fa', 'w')
-    blastdb_2 = open('blastdb_2.fa', 'w')
+    log_info(
+        "[17/23]",
+        "Checking for invalid joining using BLASTn: close strains.",
+        "\n",
+        log,
+    )
+    blastdb_1 = open("blastdb_1.fa", "w")
+    blastdb_2 = open("blastdb_2.fa", "w")
     cobraSeq2len = {}
 
     for contig in retrieved:
-        a = open('COBRA_retrieved_for_joining/{0}_retrieved_joined.fa'.format(contig), 'r')
+        a = open(
+            "COBRA_retrieved_for_joining/{0}_retrieved_joined.fa".format(contig), "r"
+        )
         for record in SeqIO.parse(a, "fasta"):
             header = str(record.id).strip()
             seq = str(record.seq)
-            cobraSeq2len[header.split('_extended', 1)[0]] = len(seq)
+            cobraSeq2len[header.split("_extended", 1)[0]] = len(seq)
 
             if len(seq) % 2 == 0:
                 half = int(len(seq) / 2)
             else:
                 half = int((len(seq) + 1) / 2)
 
-            blastdb_1.write('>' + header + '_1' + '\n')
-            blastdb_1.write(seq[:half] + '\n')
-            blastdb_2.write('>' + header + '_2' + '\n')
-            blastdb_2.write(seq[half:] + '\n')
+            blastdb_1.write(">" + header + "_1" + "\n")
+            blastdb_1.write(seq[:half] + "\n")
+            blastdb_2.write(">" + header + "_2" + "\n")
+            blastdb_2.write(seq[half:] + "\n")
 
         a.close()
 
@@ -1495,53 +1969,64 @@ def main():
         else:
             half = int((header2len[contig] + 1) / 2)
 
-        blastdb_1.write('>' + contig + '_1' + '\n')
-        blastdb_1.write(header2seq[contig][:half] + '\n')
-        blastdb_2.write('>' + contig + '_2' + '\n')
-        blastdb_2.write(header2seq[contig][half:] + '\n')
+        blastdb_1.write(">" + contig + "_1" + "\n")
+        blastdb_1.write(header2seq[contig][:half] + "\n")
+        blastdb_2.write(">" + contig + "_2" + "\n")
+        blastdb_2.write(header2seq[contig][half:] + "\n")
 
     for contig in self_circular_non_expected_overlap.keys():
-        cobraSeq2len[contig] = header2len[contig] - self_circular_non_expected_overlap[contig]
+        cobraSeq2len[contig] = (
+            header2len[contig] - self_circular_non_expected_overlap[contig]
+        )
 
         if header2len[contig] % 2 == 0:
             half = int(header2len[contig] / 2)
         else:
             half = int((header2len[contig] + 1) / 2)
 
-        blastdb_1.write('>' + contig + '_1' + '\n')
-        blastdb_1.write(header2seq[contig][:half] + '\n')
-        blastdb_2.write('>' + contig + '_2' + '\n')
-        blastdb_2.write(header2seq[contig][half:] + '\n')
+        blastdb_1.write(">" + contig + "_1" + "\n")
+        blastdb_1.write(header2seq[contig][:half] + "\n")
+        blastdb_2.write(">" + contig + "_2" + "\n")
+        blastdb_2.write(header2seq[contig][half:] + "\n")
 
     blastdb_1.close()
     blastdb_2.close()
 
     # make blastn database and run search if the database is not empty
-    if os.path.getsize('blastdb_1.fa') == 0:
-        print('no query was extended, exit! this is normal if you only provide few queries.', file=log, flush=True)
+    if os.path.getsize("blastdb_1.fa") == 0:
+        print(
+            "no query was extended, exit! this is normal if you only provide few queries.",
+            file=log,
+            flush=True,
+        )
         exit()
     else:
-        os.system('makeblastdb -in blastdb_1.fa -dbtype nucl')
-        os.system('blastn -task blastn -db blastdb_1.fa -query blastdb_2.fa -out blastdb_2.vs.blastdb_1 -evalue 1e-10 '
-                  '-outfmt 6 -perc_identity 70 -num_threads {0}'.format(args.threads))
+        os.system("makeblastdb -in blastdb_1.fa -dbtype nucl")
+        os.system(
+            "blastn -task blastn -db blastdb_1.fa -query blastdb_2.fa -out blastdb_2.vs.blastdb_1 -evalue 1e-10 "
+            "-outfmt 6 -perc_identity 70 -num_threads {0}".format(args.threads)
+        )
 
     # parse the blastn results
     contig2TotLen = {}
-    r = open('blastdb_2.vs.blastdb_1', 'r')
+    r = open("blastdb_2.vs.blastdb_1", "r")
     for line in r.readlines():
-        line = line.strip().split('\t')
-        if line[0].rsplit('_', 1)[0] == line[1].rsplit('_', 1)[0] and line[0] != line[1]:
+        line = line.strip().split("\t")
+        if (
+            line[0].rsplit("_", 1)[0] == line[1].rsplit("_", 1)[0]
+            and line[0] != line[1]
+        ):
             if float(line[3]) >= 1000:
-                if '_extended' in line[0]:
-                    if line[0].split('_extended')[0] not in contig2TotLen.keys():
-                        contig2TotLen[line[0].split('_extended')[0]] = float(line[3])
+                if "_extended" in line[0]:
+                    if line[0].split("_extended")[0] not in contig2TotLen.keys():
+                        contig2TotLen[line[0].split("_extended")[0]] = float(line[3])
                     else:
-                        contig2TotLen[line[0].split('_extended')[0]] += float(line[3])
+                        contig2TotLen[line[0].split("_extended")[0]] += float(line[3])
                 else:
-                    if line[0].rsplit('_', 1)[0] not in contig2TotLen.keys():
-                        contig2TotLen[line[0].rsplit('_', 1)[0]] = float(line[3])
+                    if line[0].rsplit("_", 1)[0] not in contig2TotLen.keys():
+                        contig2TotLen[line[0].rsplit("_", 1)[0]] = float(line[3])
                     else:
-                        contig2TotLen[line[0].rsplit('_', 1)[0]] += float(line[3])
+                        contig2TotLen[line[0].rsplit("_", 1)[0]] += float(line[3])
             else:
                 pass
         else:
@@ -1550,9 +2035,15 @@ def main():
 
     # identify potential incorrect joins and remove them from corresponding category
     for contig in contig2TotLen.keys():
-        if contig2TotLen[contig] >= 1000:  # previously, if contig2TotLen[contig] / cobraSeq2len[contig] >= 0.05
-            if os.path.exists('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(contig)):
-                a = open('COBRA_retrieved_for_joining/{0}_retrieved.fa'.format(contig), 'r')
+        if (
+            contig2TotLen[contig] >= 1000
+        ):  # previously, if contig2TotLen[contig] / cobraSeq2len[contig] >= 0.05
+            if os.path.exists(
+                "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(contig)
+            ):
+                a = open(
+                    "COBRA_retrieved_for_joining/{0}_retrieved.fa".format(contig), "r"
+                )
                 for record in SeqIO.parse(a, "fasta"):
                     header = str(record.id).strip()
                     if header in extended_partial_query:
@@ -1576,41 +2067,61 @@ def main():
             pass
 
     # for debug
-    print('extended_circular_query', file=debug, flush=True)
+    print("extended_circular_query", file=debug, flush=True)
     print(extended_circular_query, file=debug, flush=True)
-    print('extended_partial_query', file=debug, flush=True)
+    print("extended_partial_query", file=debug, flush=True)
     print(extended_partial_query, file=debug, flush=True)
-    print('contig2assembly', file=debug, flush=True)
+    print("contig2assembly", file=debug, flush=True)
     print(contig2assembly, file=debug, flush=True)
 
     ##
     # get the unique sequences of COBRA "Extended" query contigs for joining check
-    log_info('[18/23]', 'Saving unique sequences of "Extended_circular" and "Extended_partial" for joining checking.',
-             '\n', log)
-    extended_circular_fasta = open('COBRA_category_ii-a_extended_circular_unique.fasta', 'w')
-    extended_partial_fasta = open('COBRA_category_ii-b_extended_partial_unique.fasta', 'w')
+    log_info(
+        "[18/23]",
+        'Saving unique sequences of "Extended_circular" and "Extended_partial" for joining checking.',
+        "\n",
+        log,
+    )
+    extended_circular_fasta = open(
+        "COBRA_category_ii-a_extended_circular_unique.fasta", "w"
+    )
+    extended_partial_fasta = open(
+        "COBRA_category_ii-b_extended_partial_unique.fasta", "w"
+    )
     query2current = {}
 
     for contig in query_set:
-        if contig in extended_circular_query and contig not in redundant and contig not in is_same_as_redundant:
-            extended_circular_fasta.write('>' + contig + '_extended_circular' + '\n')
-            extended_circular_fasta.write(header2joined_seq[contig2extended_status[contig]] + '\n')
+        if (
+            contig in extended_circular_query
+            and contig not in redundant
+            and contig not in is_same_as_redundant
+        ):
+            extended_circular_fasta.write(">" + contig + "_extended_circular" + "\n")
+            extended_circular_fasta.write(
+                header2joined_seq[contig2extended_status[contig]] + "\n"
+            )
             extended_circular_fasta.flush()
             for item in order_all[contig]:
                 if contig_name(item) in query_set:
-                    query2current[contig_name(item)] = contig + '_extended_circular'
+                    query2current[contig_name(item)] = contig + "_extended_circular"
                 else:
                     pass
-        elif contig in extended_partial_query and contig not in redundant and contig not in is_same_as_redundant:
-            extended_partial_fasta.write('>' + contig + '_extended_partial' + '\n')
-            extended_partial_fasta.write(header2joined_seq[contig2extended_status[contig]] + '\n')
+        elif (
+            contig in extended_partial_query
+            and contig not in redundant
+            and contig not in is_same_as_redundant
+        ):
+            extended_partial_fasta.write(">" + contig + "_extended_partial" + "\n")
+            extended_partial_fasta.write(
+                header2joined_seq[contig2extended_status[contig]] + "\n"
+            )
             extended_partial_fasta.flush()
             for item in order_all[contig]:
                 if contig_name(item) in query_set:
                     if contig_name(item) in extended_partial_query:
-                        query2current[contig_name(item)] = contig + '_extended_partial'
+                        query2current[contig_name(item)] = contig + "_extended_partial"
                     elif contig_name(item) in failed_join_list:
-                        query2current[contig_name(item)] = contig + '_extended_partial'
+                        query2current[contig_name(item)] = contig + "_extended_partial"
                         extended_partial_query.add(contig_name(item))
                         failed_join_list.remove(contig_name(item))
                 else:
@@ -1619,132 +2130,287 @@ def main():
             pass
     extended_partial_fasta.close()
     extended_circular_fasta.close()
-    summary_fasta('COBRA_category_ii-a_extended_circular_unique.fasta')
-    summary_fasta('COBRA_category_ii-b_extended_partial_unique.fasta')
+    summary_fasta("COBRA_category_ii-a_extended_circular_unique.fasta")
+    summary_fasta("COBRA_category_ii-b_extended_partial_unique.fasta")
 
     # for debug
-    print('query2current', file=debug, flush=True)
+    print("query2current", file=debug, flush=True)
     print(query2current, file=debug, flush=True)
     debug.close()
 
     ##
     # save the joining details information
-    log_info('[19/23]',
-             'Getting the joining details of unique "Extended_circular" and "Extended_partial" query contigs.', '\n',
-             log)
-    joining_detail_headers = ['Final_Seq_ID', 'Joined_Len', 'Status', 'Joined_Seq_ID', 'Direction', 'Joined_Seq_Len',
-                              'Start', 'End', 'Joined_Seq_Cov', 'Joined_Seq_GC', 'Joined_reason']
-    extended_circular_joining_details = open('COBRA_category_ii-a_extended_circular_unique_joining_details.txt', 'w')
-    extended_circular_joining_details.write('\t'.join(joining_detail_headers[:]) + '\n')
-    extended_partial_joining_details = open('COBRA_category_ii-b_extended_partial_unique_joining_details.txt', 'w')
-    extended_partial_joining_details.write('\t'.join(joining_detail_headers[:]) + '\n')
+    log_info(
+        "[19/23]",
+        'Getting the joining details of unique "Extended_circular" and "Extended_partial" query contigs.',
+        "\n",
+        log,
+    )
+    joining_detail_headers = [
+        "Final_Seq_ID",
+        "Joined_Len",
+        "Status",
+        "Joined_Seq_ID",
+        "Direction",
+        "Joined_Seq_Len",
+        "Start",
+        "End",
+        "Joined_Seq_Cov",
+        "Joined_Seq_GC",
+        "Joined_reason",
+    ]
+    extended_circular_joining_details = open(
+        "COBRA_category_ii-a_extended_circular_unique_joining_details.txt", "w"
+    )
+    extended_circular_joining_details.write("\t".join(joining_detail_headers[:]) + "\n")
+    extended_partial_joining_details = open(
+        "COBRA_category_ii-b_extended_partial_unique_joining_details.txt", "w"
+    )
+    extended_partial_joining_details.write("\t".join(joining_detail_headers[:]) + "\n")
     contig2join_details = {}
 
     for contig in order_all.keys():
         site = 1
-        if contig in path_circular and contig not in redundant and contig not in is_same_as_redundant and contig not in failed_join_list:
-            contig2join_details[contig + '_extended_circular'] = []
+        if (
+            contig in path_circular
+            and contig not in redundant
+            and contig not in is_same_as_redundant
+            and contig not in failed_join_list
+        ):
+            contig2join_details[contig + "_extended_circular"] = []
             for item in order_all[contig][:-1]:
-                if get_direction(item) == 'forward':
-                    contents = [contig + '_extended_circular',
-                                str(total_length(order_all[contig]) - length * (len(order_all[contig]) - 1)),
-                                'Circular', contig_name(item), 'forward', str(header2len[contig_name(item)]), str(site),
-                                str(site + header2len[contig_name(item)] - 1),
-                                str(cov[contig_name(item)]), str(gc[contig_name(item)]),
-                                contig2join_reason[contig][contig_name(item)]]
-                    contig2join_details[contig + '_extended_circular'].append('\t'.join(contents[:]))
+                if get_direction(item) == "forward":
+                    contents = [
+                        contig + "_extended_circular",
+                        str(
+                            total_length(order_all[contig])
+                            - length * (len(order_all[contig]) - 1)
+                        ),
+                        "Circular",
+                        contig_name(item),
+                        "forward",
+                        str(header2len[contig_name(item)]),
+                        str(site),
+                        str(site + header2len[contig_name(item)] - 1),
+                        str(cov[contig_name(item)]),
+                        str(gc[contig_name(item)]),
+                        contig2join_reason[contig][contig_name(item)],
+                    ]
+                    contig2join_details[contig + "_extended_circular"].append(
+                        "\t".join(contents[:])
+                    )
                     site += header2len[contig_name(item)] - length
                 else:
-                    contents = [contig + '_extended_circular',
-                                str(total_length(order_all[contig]) - length * (len(order_all[contig]) - 1)),
-                                'Circular', contig_name(item) + '_rc', 'reverse', str(header2len[contig_name(item)]),
-                                str(site + header2len[contig_name(item)] - 1),
-                                str(site), str(cov[contig_name(item)]), str(gc[contig_name(item)]),
-                                contig2join_reason[contig][contig_name(item)]]
-                    contig2join_details[contig + '_extended_circular'].append('\t'.join(contents[:]))
+                    contents = [
+                        contig + "_extended_circular",
+                        str(
+                            total_length(order_all[contig])
+                            - length * (len(order_all[contig]) - 1)
+                        ),
+                        "Circular",
+                        contig_name(item) + "_rc",
+                        "reverse",
+                        str(header2len[contig_name(item)]),
+                        str(site + header2len[contig_name(item)] - 1),
+                        str(site),
+                        str(cov[contig_name(item)]),
+                        str(gc[contig_name(item)]),
+                        contig2join_reason[contig][contig_name(item)],
+                    ]
+                    contig2join_details[contig + "_extended_circular"].append(
+                        "\t".join(contents[:])
+                    )
                     site += header2len[contig_name(item)] - length
 
             last = order_all[contig][-1]
-            if get_direction(last) == 'forward':
-                contents = [contig + '_extended_circular',
-                            str(total_length(order_all[contig]) - length * (len(order_all[contig]) - 1)),
-                            'Circular', contig_name(last), 'forward', str(header2len[contig_name(last)]), str(site),
-                            str(site + header2len[contig_name(last)] - 1),  # length - 1),
-                            str(cov[contig_name(last)]), str(gc[contig_name(last)]),
-                            contig2join_reason[contig][contig_name(last)], '\n']
-                contig2join_details[contig + '_extended_circular'].append('\t'.join(contents[:]))
+            if get_direction(last) == "forward":
+                contents = [
+                    contig + "_extended_circular",
+                    str(
+                        total_length(order_all[contig])
+                        - length * (len(order_all[contig]) - 1)
+                    ),
+                    "Circular",
+                    contig_name(last),
+                    "forward",
+                    str(header2len[contig_name(last)]),
+                    str(site),
+                    str(site + header2len[contig_name(last)] - 1),  # length - 1),
+                    str(cov[contig_name(last)]),
+                    str(gc[contig_name(last)]),
+                    contig2join_reason[contig][contig_name(last)],
+                    "\n",
+                ]
+                contig2join_details[contig + "_extended_circular"].append(
+                    "\t".join(contents[:])
+                )
 
             else:
-                contents = [contig + '_extended_circular',
-                            str(total_length(order_all[contig]) - length * (len(order_all[contig]) - 1)),
-                            'Circular', contig_name(last) + '_rc', 'reverse', str(header2len[contig_name(last)]),
-                            str(site + header2len[contig_name(last)] - 1),  # - length - 1),
-                            str(site), str(cov[contig_name(last)]), str(gc[contig_name(last)]),
-                            contig2join_reason[contig][contig_name(last)], '\n']
-                contig2join_details[contig + '_extended_circular'].append('\t'.join(contents[:]))
-        elif contig in extended_partial_query and contig not in redundant and contig not in is_same_as_redundant:
-            contig2join_details[contig + '_extended_partial'] = []
+                contents = [
+                    contig + "_extended_circular",
+                    str(
+                        total_length(order_all[contig])
+                        - length * (len(order_all[contig]) - 1)
+                    ),
+                    "Circular",
+                    contig_name(last) + "_rc",
+                    "reverse",
+                    str(header2len[contig_name(last)]),
+                    str(site + header2len[contig_name(last)] - 1),  # - length - 1),
+                    str(site),
+                    str(cov[contig_name(last)]),
+                    str(gc[contig_name(last)]),
+                    contig2join_reason[contig][contig_name(last)],
+                    "\n",
+                ]
+                contig2join_details[contig + "_extended_circular"].append(
+                    "\t".join(contents[:])
+                )
+        elif (
+            contig in extended_partial_query
+            and contig not in redundant
+            and contig not in is_same_as_redundant
+        ):
+            contig2join_details[contig + "_extended_partial"] = []
             for item in order_all[contig][:-1]:
-                if get_direction(item) == 'forward':
-                    contents = [contig + '_extended_partial',
-                                str(total_length(order_all[contig]) - length * (len(order_all[contig]) - 1)),
-                                'Partial', contig_name(item), 'forward', str(header2len[contig_name(item)]), str(site),
-                                str(site + header2len[contig_name(item)] - 1),
-                                str(cov[contig_name(item)]), str(gc[contig_name(item)]),
-                                contig2join_reason[contig][contig_name(item)]]
-                    contig2join_details[contig + '_extended_partial'].append('\t'.join(contents[:]))
+                if get_direction(item) == "forward":
+                    contents = [
+                        contig + "_extended_partial",
+                        str(
+                            total_length(order_all[contig])
+                            - length * (len(order_all[contig]) - 1)
+                        ),
+                        "Partial",
+                        contig_name(item),
+                        "forward",
+                        str(header2len[contig_name(item)]),
+                        str(site),
+                        str(site + header2len[contig_name(item)] - 1),
+                        str(cov[contig_name(item)]),
+                        str(gc[contig_name(item)]),
+                        contig2join_reason[contig][contig_name(item)],
+                    ]
+                    contig2join_details[contig + "_extended_partial"].append(
+                        "\t".join(contents[:])
+                    )
                     site += header2len[contig_name(item)] - length
                 else:
-                    contents = [contig + '_extended_partial',
-                                str(total_length(order_all[contig]) - length * (len(order_all[contig]) - 1)),
-                                'Partial', contig_name(item) + '_rc', 'reverse', str(header2len[contig_name(item)]),
-                                str(site + header2len[contig_name(item)] - 1),
-                                str(site), str(cov[contig_name(item)]), str(gc[contig_name(item)]),
-                                contig2join_reason[contig][contig_name(item)]]
-                    contig2join_details[contig + '_extended_partial'].append('\t'.join(contents[:]))
+                    contents = [
+                        contig + "_extended_partial",
+                        str(
+                            total_length(order_all[contig])
+                            - length * (len(order_all[contig]) - 1)
+                        ),
+                        "Partial",
+                        contig_name(item) + "_rc",
+                        "reverse",
+                        str(header2len[contig_name(item)]),
+                        str(site + header2len[contig_name(item)] - 1),
+                        str(site),
+                        str(cov[contig_name(item)]),
+                        str(gc[contig_name(item)]),
+                        contig2join_reason[contig][contig_name(item)],
+                    ]
+                    contig2join_details[contig + "_extended_partial"].append(
+                        "\t".join(contents[:])
+                    )
                     site += header2len[contig_name(item)] - length
 
-            last = order_all[contig][-1]  # for the last one in non-circular path, the end position should be different
-            if get_direction(last) == 'forward':
-                contents = [contig + '_extended_partial',
-                            str(total_length(order_all[contig]) - length * (len(order_all[contig]) - 1)),
-                            'Partial', contig_name(last), 'forward', str(header2len[contig_name(last)]), str(site),
-                            str(site + header2len[contig_name(last)] - 1),
-                            str(cov[contig_name(last)]), str(gc[contig_name(last)]),
-                            contig2join_reason[contig][contig_name(last)], '\n']
-                contig2join_details[contig + '_extended_partial'].append('\t'.join(contents[:]))
+            last = order_all[contig][
+                -1
+            ]  # for the last one in non-circular path, the end position should be different
+            if get_direction(last) == "forward":
+                contents = [
+                    contig + "_extended_partial",
+                    str(
+                        total_length(order_all[contig])
+                        - length * (len(order_all[contig]) - 1)
+                    ),
+                    "Partial",
+                    contig_name(last),
+                    "forward",
+                    str(header2len[contig_name(last)]),
+                    str(site),
+                    str(site + header2len[contig_name(last)] - 1),
+                    str(cov[contig_name(last)]),
+                    str(gc[contig_name(last)]),
+                    contig2join_reason[contig][contig_name(last)],
+                    "\n",
+                ]
+                contig2join_details[contig + "_extended_partial"].append(
+                    "\t".join(contents[:])
+                )
             else:
-                contents = [contig + '_extended_partial',
-                            str(total_length(order_all[contig]) - length * (len(order_all[contig]) - 1)),
-                            'Partial', contig_name(last) + '_rc', 'reverse', str(header2len[contig_name(last)]),
-                            str(site + header2len[contig_name(last)] - 1),
-                            str(site), str(cov[contig_name(last)]), str(gc[contig_name(last)]),
-                            contig2join_reason[contig][contig_name(last)], '\n']
-                contig2join_details[contig + '_extended_partial'].append('\t'.join(contents[:]))
+                contents = [
+                    contig + "_extended_partial",
+                    str(
+                        total_length(order_all[contig])
+                        - length * (len(order_all[contig]) - 1)
+                    ),
+                    "Partial",
+                    contig_name(last) + "_rc",
+                    "reverse",
+                    str(header2len[contig_name(last)]),
+                    str(site + header2len[contig_name(last)] - 1),
+                    str(site),
+                    str(cov[contig_name(last)]),
+                    str(gc[contig_name(last)]),
+                    contig2join_reason[contig][contig_name(last)],
+                    "\n",
+                ]
+                contig2join_details[contig + "_extended_partial"].append(
+                    "\t".join(contents[:])
+                )
         else:
             pass
 
     for seq in contig2join_details.keys():
-        if 'circular' in seq:
-            extended_circular_joining_details.write('\n'.join(contig2join_details[seq][:]))
+        if "circular" in seq:
+            extended_circular_joining_details.write(
+                "\n".join(contig2join_details[seq][:])
+            )
         else:
-            extended_partial_joining_details.write('\n'.join(contig2join_details[seq][:]))
+            extended_partial_joining_details.write(
+                "\n".join(contig2join_details[seq][:])
+            )
     extended_circular_joining_details.close()
     extended_partial_joining_details.close()
 
     ##
     # save the joining summary information
-    log_info('[20/23]', 'Saving joining summary of "Extended_circular" and "Extended_partial" query contigs.', '\n',
-             log)
-    assembly_summary = open('COBRA_joining_summary.txt', 'w')
-    assembly_summary_headers = ['Query_Seq_ID', 'Query_Seq_Len', 'Total_Joined_Seqs', 'Joined_seqs', 'Total_Joined_Len',
-                                'Assembled_Len', 'Extended_Len', 'Status', 'Final_Seq_ID']
-    assembly_summary.write('\t'.join(assembly_summary_headers[:]) + '\n')
+    log_info(
+        "[20/23]",
+        'Saving joining summary of "Extended_circular" and "Extended_partial" query contigs.',
+        "\n",
+        log,
+    )
+    assembly_summary = open("COBRA_joining_summary.txt", "w")
+    assembly_summary_headers = [
+        "Query_Seq_ID",
+        "Query_Seq_Len",
+        "Total_Joined_Seqs",
+        "Joined_seqs",
+        "Total_Joined_Len",
+        "Assembled_Len",
+        "Extended_Len",
+        "Status",
+        "Final_Seq_ID",
+    ]
+    assembly_summary.write("\t".join(assembly_summary_headers[:]) + "\n")
 
     for contig in list(extended_circular_query) + list(extended_partial_query):
         if contig in query2current.keys():
             assembly_summary.write(
-                '\t'.join([contig, str(header2len[contig]), summarize(contig), query2current[contig]]) + '\n')
+                "\t".join(
+                    [
+                        contig,
+                        str(header2len[contig]),
+                        summarize(contig),
+                        query2current[contig],
+                    ]
+                )
+                + "\n"
+            )
         else:
             if contig in extended_circular_query:
                 extended_circular_query.remove(contig)
@@ -1758,111 +2424,217 @@ def main():
 
     ##
     # save the joining status information of each query
-    log_info('[21/23]', 'Saving joining status of all query contigs.', '\n', log)
-    assembled_info = open('COBRA_joining_status.txt', 'w')  # shows the COBRA status of each query
+    log_info("[21/23]", "Saving joining status of all query contigs.", "\n", log)
+    assembled_info = open(
+        "COBRA_joining_status.txt", "w"
+    )  # shows the COBRA status of each query
     assembled_info.write(
-        'SeqID' + '\t' + 'Length' + '\t' + 'Coverage' + '\t' + 'GC' + '\t' + 'Status' + '\t' + 'Category' + '\n')
+        "SeqID"
+        + "\t"
+        + "Length"
+        + "\t"
+        + "Coverage"
+        + "\t"
+        + "GC"
+        + "\t"
+        + "Status"
+        + "\t"
+        + "Category"
+        + "\n"
+    )
 
     # for those could be extended to circular
     for contig in extended_circular_query:
         assembled_info.write(
-            contig + '\t' + str(header2len[contig]) + '\t' + str(cov[contig]) + '\t' + gc[contig] + '\t'
-            + 'Extended_circular' + '\t' + 'category_ii-a' + '\n')
+            contig
+            + "\t"
+            + str(header2len[contig])
+            + "\t"
+            + str(cov[contig])
+            + "\t"
+            + gc[contig]
+            + "\t"
+            + "Extended_circular"
+            + "\t"
+            + "category_ii-a"
+            + "\n"
+        )
 
     # for those could be extended ok
     for contig in extended_partial_query:
         assembled_info.write(
-            contig + '\t' + str(header2len[contig]) + '\t' + str(cov[contig]) + '\t' + gc[contig] + '\t'
-            + 'Extended_partial' + '\t' + 'category_ii-b' + '\n')
+            contig
+            + "\t"
+            + str(header2len[contig])
+            + "\t"
+            + str(cov[contig])
+            + "\t"
+            + gc[contig]
+            + "\t"
+            + "Extended_partial"
+            + "\t"
+            + "category_ii-b"
+            + "\n"
+        )
 
     # for those cannot be extended
-    failed_join = open('COBRA_category_ii-c_extended_failed.fasta', 'w')
+    failed_join = open("COBRA_category_ii-c_extended_failed.fasta", "w")
     for contig in set(failed_join_list):
-        if contig not in extended_circular_query or contig not in extended_partial_query or contig not in orphan_end_query:
-            failed_join.write('>' + contig + '\n')
-            failed_join.write(header2seq[contig] + '\n')
-            assembled_info.write(contig + '\t' + str(header2len[contig]) + '\t' + str(cov[contig]) + '\t' + gc[contig]
-                                 + '\t' + 'Extended_failed' + '\t' + 'category_ii-c' + '\n')
+        if (
+            contig not in extended_circular_query
+            or contig not in extended_partial_query
+            or contig not in orphan_end_query
+        ):
+            failed_join.write(">" + contig + "\n")
+            failed_join.write(header2seq[contig] + "\n")
+            assembled_info.write(
+                contig
+                + "\t"
+                + str(header2len[contig])
+                + "\t"
+                + str(cov[contig])
+                + "\t"
+                + gc[contig]
+                + "\t"
+                + "Extended_failed"
+                + "\t"
+                + "category_ii-c"
+                + "\n"
+            )
         else:
             pass
     failed_join.close()
-    summary_fasta('COBRA_category_ii-c_extended_failed.fasta')
+    summary_fasta("COBRA_category_ii-c_extended_failed.fasta")
 
     # for those due to orphan end
-    orphan_end = open('COBRA_category_iii_orphan_end.fasta', 'w')
+    orphan_end = open("COBRA_category_iii_orphan_end.fasta", "w")
     for contig in orphan_end_query:
-        orphan_end.write('>' + contig + '\n')
-        orphan_end.write(header2seq[contig] + '\n')
+        orphan_end.write(">" + contig + "\n")
+        orphan_end.write(header2seq[contig] + "\n")
         assembled_info.write(
-            contig + '\t' + str(header2len[contig]) + '\t' + str(cov[contig]) + '\t' + gc[contig] + '\t'
-            + 'Orphan_end' + '\t' + 'category_iii' + '\n')
+            contig
+            + "\t"
+            + str(header2len[contig])
+            + "\t"
+            + str(cov[contig])
+            + "\t"
+            + gc[contig]
+            + "\t"
+            + "Orphan_end"
+            + "\t"
+            + "category_iii"
+            + "\n"
+        )
     orphan_end.close()
-    summary_fasta('COBRA_category_iii_orphan_end.fasta')
+    summary_fasta("COBRA_category_iii_orphan_end.fasta")
 
     # for self circular
-    log_info('[22/23]', 'Saving self_circular contigs.', '\n', log)
-    circular_fasta = open('COBRA_category_i_self_circular.fasta', 'w')
+    log_info("[22/23]", "Saving self_circular contigs.", "\n", log)
+    circular_fasta = open("COBRA_category_i_self_circular.fasta", "w")
 
     for contig in self_circular:
         assembled_info.write(
-            contig + '\t' + str(header2len[contig] - length) + '\t' + str(cov[contig]) + '\t' + gc[contig]
-            + '\t' + 'Self_circular' + '\t' + 'category_i' + '\n')
-        circular_fasta.write('>' + contig + '_self_circular' + '\n')
-        circular_fasta.write(header2seq[contig] + '\n')
+            contig
+            + "\t"
+            + str(header2len[contig] - length)
+            + "\t"
+            + str(cov[contig])
+            + "\t"
+            + gc[contig]
+            + "\t"
+            + "Self_circular"
+            + "\t"
+            + "category_i"
+            + "\n"
+        )
+        circular_fasta.write(">" + contig + "_self_circular" + "\n")
+        circular_fasta.write(header2seq[contig] + "\n")
 
     for contig in self_circular_non_expected_overlap.keys():
         assembled_info.write(
-            contig + '\t' + str(header2len[contig] - self_circular_non_expected_overlap[contig]) + '\t' +
-            str(cov[contig]) + '\t' + gc[contig] + '\t' +
-            'Self_circular' + '\t' + 'category_i' + '\n')
-        circular_fasta.write('>' + contig + '_self_circular' + '\n')
-        circular_fasta.write(header2seq[contig] + '\n')
+            contig
+            + "\t"
+            + str(header2len[contig] - self_circular_non_expected_overlap[contig])
+            + "\t"
+            + str(cov[contig])
+            + "\t"
+            + gc[contig]
+            + "\t"
+            + "Self_circular"
+            + "\t"
+            + "category_i"
+            + "\n"
+        )
+        circular_fasta.write(">" + contig + "_self_circular" + "\n")
+        circular_fasta.write(header2seq[contig] + "\n")
 
     circular_fasta.close()
     assembled_info.close()
-    summary_fasta('COBRA_category_i_self_circular.fasta')
+    summary_fasta("COBRA_category_i_self_circular.fasta")
 
     ##
     # save new fasta file with all the others used in joining replaced by COBRA sequences excepting self_circular ones
-    log_info('[23/23]', 'Saving the new fasta file.', '\n', log)
+    log_info("[23/23]", "Saving the new fasta file.", "\n", log)
 
     for contig in all_joined_query:
         del header2seq[contig]
 
-    with open('{0}.new.fa'.format(fasta_name.rsplit('.', 1)[0]), 'w') as new:
+    with open("{0}.new.fa".format(fasta_name.rsplit(".", 1)[0]), "w") as new:
         for header, sequence in header2seq.items():
             new.write(f">{header}\n{sequence}\n")
 
-    os.system('cat {0}.new.fa COBRA_category_ii-a_extended_circular_unique.fasta '
-              'COBRA_category_ii-b_extended_partial_unique.fasta '
-              '>{0}.new.fa.'.format(fasta_name.rsplit('.', 1)[0]))
-    os.system('mv {0}.new.fa. {0}.new.fa'.format(fasta_name.rsplit('.', 1)[0]))
+    os.system(
+        "cat {0}.new.fa COBRA_category_ii-a_extended_circular_unique.fasta "
+        "COBRA_category_ii-b_extended_partial_unique.fasta "
+        ">{0}.new.fa.".format(fasta_name.rsplit(".", 1)[0])
+    )
+    os.system("mv {0}.new.fa. {0}.new.fa".format(fasta_name.rsplit(".", 1)[0]))
 
     ##
     # intermediate files
-    os.mkdir('intermediate.files')
+    os.mkdir("intermediate.files")
     os.system(
-        'mv COBRA_end_joining_pairs.txt COBRA_potential_joining_paths.txt COBRA_retrieved_for_joining intermediate.files')
-    os.mkdir('intermediate.files/invalid.checking')
-    os.system('mv blastdb_1.fa* blastdb_2.fa blastdb_2.vs.blastdb_1* intermediate.files/invalid.checking')
+        "mv COBRA_end_joining_pairs.txt COBRA_potential_joining_paths.txt COBRA_retrieved_for_joining intermediate.files"
+    )
+    os.mkdir("intermediate.files/invalid.checking")
+    os.system(
+        "mv blastdb_1.fa* blastdb_2.fa blastdb_2.vs.blastdb_1* intermediate.files/invalid.checking"
+    )
 
     ##
     # write the numbers to the log file
-    log.write('\n')
-    log.write('3. RESULTS SUMMARY' + '\n')
-    log.write('# Total queries: ' + str(len(query_set)) + '\n' +
-              '# Category i   - Self_circular: ' + str(count_seq('COBRA_category_i_self_circular.fasta')) + '\n' +
-              '# Category ii  - Extended_circular: ' + str(len(extended_circular_query)) + ' (Unique: ' +
-              str(count_seq('COBRA_category_ii-a_extended_circular_unique.fasta')) + ')\n' +
-              '# Category ii  - Extended_partial: ' + str(len(extended_partial_query)) + ' (Unique: ' +
-              str(count_seq('COBRA_category_ii-b_extended_partial_unique.fasta')) + ')\n' +
-              '# Category ii  - Extended_failed (due to COBRA rules): ' + str(len(set(failed_join_list))) + '\n' +
-              '# Category iii - Orphan end: ' + str(len(orphan_end_query)) + '\n' +
-              '# Check "COBRA_joining_status.txt" for joining status of each query.' + '\n' +
-              '# Check "COBRA_joining_summary.txt" for joining details of "Extended_circular" and "Extended_partial" queries.')
+    log.write("\n")
+    log.write("3. RESULTS SUMMARY" + "\n")
+    log.write(
+        "# Total queries: "
+        + str(len(query_set))
+        + "\n"
+        + "# Category i   - Self_circular: "
+        + str(count_seq("COBRA_category_i_self_circular.fasta"))
+        + "\n"
+        + "# Category ii  - Extended_circular: "
+        + str(len(extended_circular_query))
+        + " (Unique: "
+        + str(count_seq("COBRA_category_ii-a_extended_circular_unique.fasta"))
+        + ")\n"
+        + "# Category ii  - Extended_partial: "
+        + str(len(extended_partial_query))
+        + " (Unique: "
+        + str(count_seq("COBRA_category_ii-b_extended_partial_unique.fasta"))
+        + ")\n"
+        + "# Category ii  - Extended_failed (due to COBRA rules): "
+        + str(len(set(failed_join_list)))
+        + "\n"
+        + "# Category iii - Orphan end: "
+        + str(len(orphan_end_query))
+        + "\n"
+        + '# Check "COBRA_joining_status.txt" for joining status of each query.'
+        + "\n"
+        + '# Check "COBRA_joining_summary.txt" for joining details of "Extended_circular" and "Extended_partial" queries.'
+    )
     log.flush()
     log.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Previously, if a query contig is link to a extended circle, and the query also fall into failed_join_potential, then it may raise key error afterward.

For example:
![image](https://github.com/user-attachments/assets/c2e2f82a-d6f5-45aa-be73-78ace2f3168e)
```dot
graph {
    rankdir = "LR";
    ordering = "in";
    node [shape = plain;];
    
    k141_374016_L -- k141_374016_R [color=red;label="cov=2.6159"]
    k141_1275772_L -- k141_1275772_R [color=blue;label="cov=5.569"]
    k141_158261_L -- k141_158261_R [color=green;label="cov=1.2559"]
    k141_21772_L -- k141_21772_R [color=orange;label="cov=9.930"]

    k141_374016_L -- k141_158261_R [color=red]
                     k141_158261_L -- k141_21772_R [color=red]
    k141_374016_R -- k141_21772_L [color=red]
                     k141_21772_R -- k141_158261_L [color=red]

    k141_158261_L -- k141_21772_R [color=green]
                     k141_21772_L -- k141_1275772_R [color=green]
    k141_158261_R -- k141_374016_L [color=green]
                     k141_374016_R -- k141_21772_L [color=green]

    k141_21772_L -- k141_1275772_R [color=orange]
    k141_21772_R -- k141_158261_L [color=orange]
    k141_158261_R -- k141_374016_L [color=orange]

}
```