### PR TITLE
fix: fix handle of "6" shape path

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,13 +32,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Setup environment
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: cobra
           create-args: blast python pytest biopython pysam
           cache-environment: true
+          condarc: |
+            channels:
+              - conda-forge
+              - bioconda
+              - defaults
           init-shell: bash
+
       - name: Test local
         env:
           CI: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,7 +37,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: cobra
-          create-args: blast python pytest biopython pysam
+          create-args: blast python pytest biopython pysam pandas
           cache-environment: true
           condarc: |
             channels:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
           cache-environment: false
 
       - name: Check formatting
-        run: black --check --diff .
+        run: black --check --diff cobra.py tests.py
 
   testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,48 @@
+name: Python Package using Conda
+
+on: [push]
+
+defaults:
+  run:
+    shell: bash -el {0}
+
+jobs:
+  formatting:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      pull-requests: write # for marocchino/sticky-pull-request-comment to create or update PR comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: black
+          create-args: black
+          cache-environment: false
+
+      - name: Check formatting
+        run: black --check --diff .
+
+  testing:
+    runs-on: ubuntu-latest
+    needs: formatting
+    strategy:
+      max-parallel: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: cobra
+          create-args: blast python pytest biopython pysam
+          cache-environment: true
+          init-shell: bash
+      - name: Test local
+        env:
+          CI: true
+        run: |
+          for i in {1..5}; do
+            pytest tests.py
+          done

--- a/cobra.py
+++ b/cobra.py
@@ -12,7 +12,6 @@ import itertools
 import os
 from collections import defaultdict
 from pathlib import Path
-import pickle
 import sys
 from time import strftime
 from typing import Callable, Iterable, KeysView, Literal, NamedTuple, TextIO, TypeVar

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,172 @@
+from cobra import *
+from cobra import _get_subset_trunks
+
+query_set = frozenset({"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"})
+
+
+def test_get_sub_trunks_conflict():
+    # fmt: off
+    contig2assembly = {
+        "A": {"A", "B"     },
+        "B": {     "B", "C"},
+        "C": {"A", "B", "C"},
+    }
+    # fmt: on
+    groups2ext_query = dict(
+        enumerate(
+            sorted(
+                query2groups(contig2assembly, query_set=query_set),
+                key=lambda d: sorted(d),
+            )
+        )
+    )
+    subset_trunks, _unextendable, _failed_reason = _get_subset_trunks(
+        0, groups2ext_query[0]
+    )
+    print(f"{subset_trunks=}", f"{_unextendable=}", f"{_failed_reason=}", sep="\n")
+    print()
+    assert subset_trunks == {}
+    assert set(_unextendable) == {"A", "B", "C"}
+    assert set(_failed_reason) == {"A", "B", "C"}
+
+
+def test_get_sub_trunks_subs():
+    # fmt: off
+    contig2assembly = {
+        "A": {"A",              },
+        "B": {"A", "B"          },
+        "C": {          "C", "D"},
+        "D": {"A", "B", "C", "D"},
+    }
+    # fmt: on
+    groups2ext_query = dict(
+        enumerate(
+            sorted(
+                query2groups(contig2assembly, query_set=query_set),
+                key=lambda d: sorted(d),
+            )
+        )
+    )
+    print(groups2ext_query)
+
+    subset_trunks, _unextendable, _failed_reason = _get_subset_trunks(
+        0, groups2ext_query[0]
+    )
+    print(f"{subset_trunks=}", f"{_unextendable=}", f"{_failed_reason=}", sep="\n")
+    assert subset_trunks == {
+        "D": SubsetChunk(
+            standalong_subs={
+                "B": SubsetChunk(standalong_subs={}, frags=["A", "B"]),
+                "C": SubsetChunk(standalong_subs={}, frags=["C"]),
+            },
+            frags=["D"],
+        )
+    }
+    assert not set(_unextendable)
+    assert not set(_failed_reason)
+
+
+def test_get_sub_trunks_sub_only():
+    # fmt: off
+    contig2assembly = {
+        "A": {"A", "B"          },
+        "B": {     "B", "C", "D"},
+        "C": {          "C", "D"},
+        "D": {"A", "B", "C", "D"},
+    }
+    # fmt: on
+    groups2ext_query = dict(
+        enumerate(
+            sorted(
+                query2groups(contig2assembly, query_set=query_set),
+                key=lambda d: sorted(d),
+            )
+        )
+    )
+    print(groups2ext_query)
+
+    subset_trunks, _unextendable, _failed_reason = _get_subset_trunks(
+        0, groups2ext_query[0]
+    )
+    print(f"{subset_trunks=}", f"{_unextendable=}", f"{_failed_reason=}", sep="\n")
+    assert subset_trunks == {"C": SubsetChunk(standalong_subs={}, frags=["C"])}
+    assert set(_unextendable) == {"A", "B", "D"}
+    assert set(_failed_reason) == {"A", "B", "D"}
+
+
+def test_get_sub_trunks_real():
+    # fmt: off
+    query_set = frozenset((           "AcMG_5518", "AcMG_12242", "AcMG_3793", "AcMG_755", "AcMG_9925", "AcMG_9528"))
+    contig2assembly = {
+        "AcMG_3793" : {"AcMG_925032", "AcMG_5518", "AcMG_12242", "AcMG_3793"},
+        "AcMG_755"  : {"AcMG_925032", "AcMG_5518", "AcMG_12242", "AcMG_3793", "AcMG_755", "AcMG_9925"},
+        "AcMG_12242": {"AcMG_925032"} | query_set,
+        "AcMG_5518" : {"AcMG_925032"} | query_set,
+        "AcMG_9925" : {"AcMG_925032"} | query_set,
+    }
+    # fmt: on
+    groups2ext_query = dict(
+        enumerate(
+            sorted(
+                query2groups(contig2assembly, query_set=query_set),
+                key=lambda d: sorted(d),
+            )
+        )
+    )
+    assert set(groups2ext_query[0].values()) == set(
+        {
+            "AcMG_3793": GroupAssemblyIndex(
+                special=frozenset({"AcMG_12242"}), dup_queries=frozenset()
+            ),
+            "AcMG_755": GroupAssemblyIndex(
+                special=frozenset({"AcMG_755", "AcMG_12242"}), dup_queries=frozenset()
+            ),
+            "AcMG_5518": GroupAssemblyIndex(
+                special=frozenset({"AcMG_755", "AcMG_9528", "AcMG_12242"}),
+                dup_queries=frozenset({"AcMG_12242", "AcMG_5518", "AcMG_9925"}),
+            ),
+        }.values()
+    )
+    print(groups2ext_query)
+
+    subset_trunks, _unextendable, _failed_reason = _get_subset_trunks(
+        0, groups2ext_query[0]
+    )
+    print(f"{subset_trunks=}", f"{_unextendable=}", f"{_failed_reason=}", sep="\n")
+    assert len(subset_trunks) == 1
+    (subset,) = subset_trunks.values()
+    assert subset.standalong_subs == {}
+    assert {"AcMG_3793", "AcMG_755"} < set(subset.frags) and len(subset.frags) == 3
+    assert _unextendable == set()
+    assert _failed_reason == {}
+
+    assembly_reason = get_assembly2reason(
+        0,
+        groups2ext_query[0],
+        contig2assembly=contig2assembly,
+        path_circular_potential=frozenset({"AcMG_755"}),
+        contig_link_no_pe=frozenset({"AcMG_9528"}),
+    )
+    print(assembly_reason)
+    assert assembly_reason == {
+        "AcMG_755": AssemblyReason(
+            groupid=0,
+            judgement="circular_6_conflict",
+            represent_seqs=assembly_reason["AcMG_755"].represent_seqs,
+            dup_queries=frozenset(),
+        ),
+        "AcMG_3793": AssemblyReason(
+            groupid=0,
+            judgement="longest",
+            represent_seqs=["AcMG_3793"],
+            dup_queries=frozenset(),
+        ),
+    }
+    assert len(assembly_reason["AcMG_755"].represent_seqs) == 2
+    assert assembly_reason["AcMG_755"].represent_seqs[0] == "AcMG_755"
+
+
+test_get_sub_trunks_conflict()
+test_get_sub_trunks_subs()
+test_get_sub_trunks_sub_only()
+test_get_sub_trunks_real()


### PR DESCRIPTION
will fix #43

## background
in the issue, queries are extended as follow pattern:
![1368a2bafc107fc2e242dd719e03867](https://github.com/user-attachments/assets/f3536479-4ce3-4c3f-9533-063c80d4cb8a)

and the environment is:
```python
query_set = frozenset((           "AcMG_5518", "AcMG_12242", "AcMG_3793", "AcMG_755", "AcMG_9925", "AcMG_9528"))
contig2assembly = {
    "AcMG_3793" : {"AcMG_925032", "AcMG_5518", "AcMG_12242", "AcMG_3793"},
    "AcMG_755"  : {"AcMG_925032", "AcMG_5518", "AcMG_12242", "AcMG_3793", "AcMG_755", "AcMG_9925"},
    "AcMG_12242": {"AcMG_925032"} | query_set,
    "AcMG_5518" : {"AcMG_925032"} | query_set,
    "AcMG_9925" : {"AcMG_925032"} | query_set,
}
path_circular_potential=frozenset({"AcMG_755"})
contig_link_no_pe=frozenset({"AcMG_9528"})
```

## bug analysis
in this case, a query (`AcMG_9528`) exists as an arm of a ring (represenated by `AcMG_755`). In this case, both the ring and the longer path should be marked as failed. A shorter not-ring path inner the failed ring can be reported instead (but failed for bug)

## fixes:
1. fix the bug report here. Now the shortest common path are kept.
2. make code easier to read (seperate functions and NamedTuple)
3. fix other bugs via adding tests